### PR TITLE
Pass username through url decoder.

### DIFF
--- a/shims/url/index.ts
+++ b/shims/url/index.ts
@@ -4,6 +4,8 @@ export function parse(url: string, parseQueryString = false) {
   const httpUrl = 'http:' + url.substring(protocol.length);
   let { username, password, host, hostname, port, pathname, search, searchParams, hash } = new URL(httpUrl);
   password = decodeURIComponent(password);
+  username = decodeURIComponent(username);
+  pathname = decodeURIComponent(pathname);
   const auth = username + ':' + password;
   const query = parseQueryString ? Object.fromEntries(searchParams.entries()) : search;
   return { href: url, protocol, auth, username, password, host, hostname, port, pathname, search, query, hash };


### PR DESCRIPTION
Postgres protocol expects raw usernames, so users with non-url-safe characters in their username can't properly authorize.