### PR TITLE
Add stack traces to NeonDbError when captureStackTrace is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+Capture stack traces in `NeonDbError`, if `Error.captureStackTrace` is available.
+
 ## 0.9.3 (2024-05-09)
 
 Expose all error information fields on `NeonDbError` objects thrown when using the http fetch transport.

--- a/export/httpQuery.ts
+++ b/export/httpQuery.ts
@@ -28,6 +28,14 @@ export class NeonDbError extends Error {
   routine: string | undefined;
 
   sourceError: Error | undefined;
+
+  constructor(message: string) {
+    super(message);
+
+    if ("captureStackTrace" in Error && typeof Error.captureStackTrace === "function") {
+      Error.captureStackTrace(this, NeonDbError);
+    }
+  }
 }
 
 interface ParameterizedQuery {


### PR DESCRIPTION
Fixes https://github.com/neondatabase/serverless/issues/82