### PR TITLE
Setup bash script to facilitate experimenta releases

### DIFF
--- a/setup-release-branch.sh
+++ b/setup-release-branch.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Generate a unique branch name using a timestamp
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+NEW_BRANCH="release-branch-$TIMESTAMP"
+
+# Create an empty tree
+empty_tree=$(git hash-object -t tree /dev/null)
+
+# Create a new commit with just the contents of dist/npm
+new_commit=$(git commit-tree -m "Add npm distribution files" $(git write-tree --prefix=dist/npm))
+
+# Create the new branch pointing to this commit
+git update-ref "refs/heads/$NEW_BRANCH" $new_commit
+
+# Push the new branch to the remote repository
+git push origin $NEW_BRANCH
+
+echo "New branch '$NEW_BRANCH' has been created and pushed with the contents of /dist/npm"
+echo "----------------------------"
+echo "Install this branch using:"
+echo "npm install '@neondatabase/serverless'@'github:neondatabase/serverless#$NEW_BRANCH'"

--- a/setup-release-branch.sh
+++ b/setup-release-branch.sh
@@ -1,22 +1,25 @@
 #!/bin/bash
+set -eux
 
 # Generate a unique branch name using a timestamp
 TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
 NEW_BRANCH="release-branch-$TIMESTAMP"
 
 # Create an empty tree
-empty_tree=$(git hash-object -t tree /dev/null)
+git hash-object -t tree /dev/null
 
 # Create a new commit with just the contents of dist/npm
-new_commit=$(git commit-tree -m "Add npm distribution files" $(git write-tree --prefix=dist/npm))
+new_commit=$(git commit-tree -m "Add npm distribution files" "$(git write-tree --prefix=dist/npm)")
 
 # Create the new branch pointing to this commit
-git update-ref "refs/heads/$NEW_BRANCH" $new_commit
+git update-ref "refs/heads/$NEW_BRANCH" "$new_commit"
 
 # Push the new branch to the remote repository
-git push origin $NEW_BRANCH
+git push origin "$NEW_BRANCH"
 
+set +x
 echo "New branch '$NEW_BRANCH' has been created and pushed with the contents of /dist/npm"
 echo "----------------------------"
 echo "Install this branch using:"
 echo "npm install '@neondatabase/serverless'@'github:neondatabase/serverless#$NEW_BRANCH'"
+set -x


### PR DESCRIPTION
## Description

This PR aims to facilitate publishing an experimental release as a side git branch, that can later be consumed through a package manger like `npm` or `bun`.

**SCRIPT FUNCTIONALITY**
- creates a side branch with the timestamp on its name (so that it is unique)
- commits the contents of `dist/npm` into this side branch
- pushes the content to remote
- prints a message of how to install this new release with `npm`

![image](https://github.com/user-attachments/assets/9006cf13-8622-4024-8a58-b0d31d224102)

**NOTES**

This was the same process I did to release the experimental `release-jwt-token` branch, but now automated.

## Test Plan

Tested locally as shown here 👇 


https://github.com/user-attachments/assets/7d47a739-19cc-46a5-bf93-0e3c2bc2cc26
