### PR TITLE
chore: bump npm and JSR versions to v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.1 (2024-10-07)
+
+Fix `CONFIG.MD` documentation.
+
 ## 0.10.0 (2024-10-07)
 
 Capture stack traces in `NeonDbError`, if `Error.captureStackTrace` is available.

--- a/dist/jsr/jsr.json
+++ b/dist/jsr/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@neon/serverless",
-  "version": "0.9.5",
+  "version": "0.10.1",
   "exports": "./index.js",
   "imports": {
     "pg": "npm:@types/pg@8.11.6"

--- a/dist/npm/CHANGELOG.md
+++ b/dist/npm/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.1 (2024-10-07)
+
+Fix `CONFIG.MD` documentation.
+
 ## 0.10.0 (2024-10-07)
 
 Capture stack traces in `NeonDbError`, if `Error.captureStackTrace` is available.

--- a/dist/npm/CONFIG.md
+++ b/dist/npm/CONFIG.md
@@ -108,6 +108,22 @@ const rows = await sql('SELECT * FROM posts WHERE id = $1', [postId], {
 clearTimeout(timeout);
 ```
 
+### `authToken: string | (() => Promise<string> | string)`
+
+The `authToken` option can be passed to `neon(...)` to set the `Authorization` header for the `fetch` request. This allows you to authenticate database requests against third-party authentication providers. So, this mechanism can be used to ensure that access control and authorization are managed effectively across different systems.
+
+Example of usage:
+
+```typescript
+import { neon } from '@neondatabase/serverless';
+// Retrieve the JWT token (implementation depends on your auth system)
+const authToken = getAuthToken();
+// Initialize the Neon client with a connection string and auth token
+const sql = neon(process.env.DATABASE_URL, { authToken });
+// Run a query
+const posts = await sql('SELECT * FROM posts');
+```
+
 ## `transaction(...)` function
 
 The `transaction(queriesOrFn, options)` function is exposed as a property on the query function. It allows multiple queries to be executed within a single, non-interactive transaction.

--- a/dist/npm/package-lock.json
+++ b/dist/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neondatabase/serverless",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@neondatabase/serverless",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "MIT",
       "dependencies": {
         "@types/pg": "^8.6.6"

--- a/dist/npm/package.json
+++ b/dist/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neondatabase/serverless",
-  "version": "0.9.5",
+  "version": "0.10.1",
   "author": "Neon",
   "description": "node-postgres for serverless environments from neon.tech",
   "exports": {


### PR DESCRIPTION
## Descriptions

This PR aims to bump the versions of both the `npm` and the `JSR` packages.

**Published versions** 👇 

npm: https://www.npmjs.com/package/@neondatabase/serverless
JSR: https://jsr.io/@neon/serverless

## Test Plan

I tested the published node version manually and it worked just fine 👍 