### PR TITLE
expose types property on public HTTPQueryOptions type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+expose types property on public HTTPQueryOptions type
+
 ## 0.10.1 (2024-10-07)
 
 Fix `CONFIG.MD` documentation.

--- a/dist/jsr/index.d.ts
+++ b/dist/jsr/index.d.ts
@@ -163,6 +163,7 @@ import {
   ClientBase as PgClientBase,
   Pool as PgPool,
   PoolClient as PgPoolClient,
+  types as PgTypes
 } from "pg";
 
 export class ClientBase extends PgClientBase {
@@ -240,6 +241,12 @@ export interface HTTPQueryOptions<ArrayMode extends boolean, FullResults extends
    * Default: `undefined`
   */
   authToken?: string | (() => Promise<string> | string);
+
+  /**
+   * Custom type parsers
+   * See https://github.com/brianc/node-pg-types
+   */
+  types?: typeof PgTypes;
 }
 
 export interface HTTPTransactionOptions<ArrayMode extends boolean, FullResults extends boolean> extends HTTPQueryOptions<ArrayMode, FullResults> {

--- a/dist/npm/index.d.mts
+++ b/dist/npm/index.d.mts
@@ -167,6 +167,7 @@ import {
   ClientBase as PgClientBase,
   Pool as PgPool,
   PoolClient as PgPoolClient,
+  types as PgTypes
 } from "pg";
 
 export class ClientBase extends PgClientBase {
@@ -244,6 +245,12 @@ export interface HTTPQueryOptions<ArrayMode extends boolean, FullResults extends
    * Default: `undefined`
   */
   authToken?: string | (() => Promise<string> | string);
+
+  /**
+   * Custom type parsers
+   * See https://github.com/brianc/node-pg-types
+   */
+  types?: typeof PgTypes;
 }
 
 export interface HTTPTransactionOptions<ArrayMode extends boolean, FullResults extends boolean> extends HTTPQueryOptions<ArrayMode, FullResults> {

--- a/dist/npm/index.d.ts
+++ b/dist/npm/index.d.ts
@@ -163,6 +163,7 @@ import {
   ClientBase as PgClientBase,
   Pool as PgPool,
   PoolClient as PgPoolClient,
+  types as PgTypes
 } from "pg";
 
 export class ClientBase extends PgClientBase {
@@ -240,6 +241,12 @@ export interface HTTPQueryOptions<ArrayMode extends boolean, FullResults extends
    * Default: `undefined`
   */
   authToken?: string | (() => Promise<string> | string);
+
+  /**
+   * Custom type parsers
+   * See https://github.com/brianc/node-pg-types
+   */
+  types?: typeof PgTypes;
 }
 
 export interface HTTPTransactionOptions<ArrayMode extends boolean, FullResults extends boolean> extends HTTPQueryOptions<ArrayMode, FullResults> {

--- a/export/httpQuery.ts
+++ b/export/httpQuery.ts
@@ -50,8 +50,9 @@ interface HTTPQueryOptions {
   arrayMode?: boolean; // default false
   fullResults?: boolean; // default false
   fetchOptions?: Record<string, any>;
-  // these callback options are not currently exported:
   types?: typeof defaultTypes;
+
+  // these callback options are not currently exported:
   queryCallback?: (query: ParameterizedQuery) => void;
   resultCallback?: (
     query: ParameterizedQuery,


### PR DESCRIPTION
Support for passing custom type overrides was recently added in [#92](https://github.com/neondatabase/serverless/pull/92)

Having confirmed it works, the types property needs to be added to the public types declaration files in order to be able to use it directly on the neon() function.

(This is required to fix types support for the PrismaNeonHTTP adapter)

Fixes https://github.com/neondatabase/serverless/issues/109