### PR TITLE
Correct type of `types` option to `CustomTypesConfig`

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -108,7 +108,7 @@ const rows = await sql('SELECT * FROM posts WHERE id = $1', [postId], {
 clearTimeout(timeout);
 ```
 
-### `types: typeof PgTypes`
+### `types: CustomTypesConfig`
 
 The `types` option can be passed to `neon(...)` to override the default PostgreSQL type parsers provided by `PgTypes`. This is useful if you want to define custom parsing behavior for specific PostgreSQL data types, allowing you to control how data is converted when retrieved from the database. Learn more in the [PgTypes official documentation](https://github.com/brianc/node-pg-types).
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -118,16 +118,23 @@ Example of usage:
 import PgTypes from 'pg-types';
 import { neon } from '@neondatabase/serverless';
 
-// Define custom parsers for specific PostgreSQL types
-// Parse PostgreSQL `DATE` fields as JavaScript `Date` objects
-PgTypes.setTypeParser(PgTypes.builtins.DATE, (val) => new Date(val));
-
-// Parse PostgreSQL `NUMERIC` fields as JavaScript `float` values
-PgTypes.setTypeParser(PgTypes.builtins.NUMERIC, parseFloat);
-
 // Configure the Neon client with the custom `types` parser
 const sql = neon(process.env.DATABASE_URL, {
-  types: PgTypes, // Pass in the custom PgTypes object here
+  types: {
+    getTypeParser: ((oid, format?: any) => {
+      // Define custom parsers for specific PostgreSQL types
+      // Parse PostgreSQL `DATE` fields as JavaScript `Date` objects
+      if (oid === PgTypes.builtins.DATE) {
+        return (val: any) => new Date(val);
+      }
+      // Parse PostgreSQL `NUMERIC` fields as JavaScript `float` values
+      if (oid === PgTypes.builtins.NUMERIC) {
+        return parseFloat;
+      }
+      // For all other types, use the default parser
+      return PgTypes.getTypeParser(oid, format);
+    }) as typeof PgTypes.getTypeParser,
+  },
 });
 ```
 

--- a/dist/jsr/index.d.ts
+++ b/dist/jsr/index.d.ts
@@ -161,9 +161,9 @@ export interface NeonConfig extends NeonConfigGlobalOnly, NeonConfigGlobalAndCli
 import {
   Client as PgClient,
   ClientBase as PgClientBase,
+  CustomTypesConfig,
   Pool as PgPool,
-  PoolClient as PgPoolClient,
-  types as PgTypes
+  PoolClient as PgPoolClient
 } from "pg";
 
 export class ClientBase extends PgClientBase {
@@ -246,7 +246,7 @@ export interface HTTPQueryOptions<ArrayMode extends boolean, FullResults extends
    * Custom type parsers
    * See https://github.com/brianc/node-pg-types
    */
-  types?: typeof PgTypes;
+  types?: CustomTypesConfig;
 }
 
 export interface HTTPTransactionOptions<ArrayMode extends boolean, FullResults extends boolean> extends HTTPQueryOptions<ArrayMode, FullResults> {

--- a/dist/npm/index.d.mts
+++ b/dist/npm/index.d.mts
@@ -165,9 +165,9 @@ export interface NeonConfig extends NeonConfigGlobalOnly, NeonConfigGlobalAndCli
 import {
   Client as PgClient,
   ClientBase as PgClientBase,
+  CustomTypesConfig,
   Pool as PgPool,
-  PoolClient as PgPoolClient,
-  types as PgTypes
+  PoolClient as PgPoolClient
 } from "pg";
 
 export class ClientBase extends PgClientBase {
@@ -250,7 +250,7 @@ export interface HTTPQueryOptions<ArrayMode extends boolean, FullResults extends
    * Custom type parsers
    * See https://github.com/brianc/node-pg-types
    */
-  types?: typeof PgTypes;
+  types?: CustomTypesConfig;
 }
 
 export interface HTTPTransactionOptions<ArrayMode extends boolean, FullResults extends boolean> extends HTTPQueryOptions<ArrayMode, FullResults> {

--- a/dist/npm/index.d.ts
+++ b/dist/npm/index.d.ts
@@ -161,9 +161,9 @@ export interface NeonConfig extends NeonConfigGlobalOnly, NeonConfigGlobalAndCli
 import {
   Client as PgClient,
   ClientBase as PgClientBase,
+  CustomTypesConfig,
   Pool as PgPool,
-  PoolClient as PgPoolClient,
-  types as PgTypes
+  PoolClient as PgPoolClient
 } from "pg";
 
 export class ClientBase extends PgClientBase {
@@ -246,7 +246,7 @@ export interface HTTPQueryOptions<ArrayMode extends boolean, FullResults extends
    * Custom type parsers
    * See https://github.com/brianc/node-pg-types
    */
-  types?: typeof PgTypes;
+  types?: CustomTypesConfig;
 }
 
 export interface HTTPTransactionOptions<ArrayMode extends boolean, FullResults extends boolean> extends HTTPQueryOptions<ArrayMode, FullResults> {

--- a/export/httpQuery.ts
+++ b/export/httpQuery.ts
@@ -1,4 +1,4 @@
-import { types as defaultTypes } from '.';
+import type { CustomTypesConfig } from 'pg';
 import { Socket } from '../shims/net';
 import { parse } from '../shims/url';
 
@@ -50,7 +50,7 @@ interface HTTPQueryOptions {
   arrayMode?: boolean; // default false
   fullResults?: boolean; // default false
   fetchOptions?: Record<string, any>;
-  types?: typeof defaultTypes;
+  types?: CustomTypesConfig;
 
   // these callback options are not currently exported:
   queryCallback?: (query: ParameterizedQuery) => void;
@@ -87,7 +87,7 @@ interface ProcessQueryResultOptions {
   fullResults: boolean;
   parameterizedQuery: ParameterizedQuery;
   resultCallback: HTTPQueryOptions['resultCallback'];
-  types?: typeof defaultTypes;
+  types?: CustomTypesConfig;
 }
 
 const txnArgErrMsg =


### PR DESCRIPTION
Context: https://github.com/neondatabase/serverless/pull/110#issuecomment-2459199983

I've also updated the example in CONFIG.md, although the way pg's types are written seem to require userland use of `any` on the format parameter and `as typeof PgTypes.getTypeParser` cast on the custom implementation of `getTypeParser()`, which is quite displeasing 😭 

It may be preferable to keep the current example for simplicity (as it doesn't require these userland typescript workarounds), potentially with a warning about global scope pollution. 🤷‍♂️ 