### PR TITLE
Fix: Cannot Read Properties of Null (Reading 'send')

### DIFF
--- a/shims/net/index.ts
+++ b/shims/net/index.ts
@@ -501,7 +501,9 @@ export class Socket extends EventEmitter {
     if (this.writeBuffer === undefined) {
       this.writeBuffer = data;
       setTimeout(() => {
-        this.ws!.send(this.writeBuffer!);
+        if(this.ws) {
+          this.ws!.send(this.writeBuffer!);
+        }
         this.writeBuffer = undefined;
       }, 0);
     } else {


### PR DESCRIPTION
Fix to resolve: https://github.com/neondatabase/serverless/issues/131
Tested with wrangler locally.