### PR TITLE
Fixed jsr.json

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -6,13 +6,15 @@
     "pg": "npm:@types/pg@8.8.0",
     "node": "npm:@types/node@22.10.2"
   },
-  "include": [
-    "index.mjs",
-    "index.d.mts",
-    "README.md",
-    "LICENSE",
-    "CHANGELOG.md",
-    "CONFIG.md",
-    "DEPLOY.md"
-  ]
+  "publish": {
+    "include": [
+      "index.mjs",
+      "index.d.mts",
+      "README.md",
+      "LICENSE",
+      "CHANGELOG.md",
+      "CONFIG.md",
+      "DEPLOY.md"
+    ]
+  }
 }


### PR DESCRIPTION
Fixed an existing issue in `jsr.json`: we need to select the published files via `{ "publish": { "include": [ ... ] }`, not just  `{ "include": [ ... ] }`.

This wasn't previously apparent because the file structure was different.