### PR TITLE
gh-workflow-stats-action v0.2.2 with using ghcr

### DIFF
--- a/.github/workflows/report-workflow-stats-batch.yml
+++ b/.github/workflows/report-workflow-stats-batch.yml
@@ -23,7 +23,7 @@ jobs:
           egress-policy: audit
 
       - name: Export Workflow Run for the past 2 hours
-        uses: neondatabase/gh-workflow-stats-action@4c998b25ab5cc6588b52a610b749531f6a566b6b # v0.2.1
+        uses: neondatabase/gh-workflow-stats-action@701b1f202666d0b82e67b4d387e909af2b920127 # v0.2.2
         with:
           db_uri: ${{ secrets.GH_REPORT_STATS_DB_RW_CONNSTR }}
           db_table: 'gh_workflow_stats_serverless'
@@ -43,7 +43,7 @@ jobs:
           egress-policy: audit
 
       - name: Export Workflow Run for the past 48 hours
-        uses: neondatabase/gh-workflow-stats-action@4c998b25ab5cc6588b52a610b749531f6a566b6b # v0.2.1
+        uses: neondatabase/gh-workflow-stats-action@701b1f202666d0b82e67b4d387e909af2b920127 # v0.2.2
         with:
           db_uri: ${{ secrets.GH_REPORT_STATS_DB_RW_CONNSTR }}
           db_table: 'gh_workflow_stats_serverless'
@@ -63,7 +63,7 @@ jobs:
           egress-policy: audit
 
       - name: Export Workflow Run for the past 30 days
-        uses: neondatabase/gh-workflow-stats-action@4c998b25ab5cc6588b52a610b749531f6a566b6b # v0.2.1
+        uses: neondatabase/gh-workflow-stats-action@701b1f202666d0b82e67b4d387e909af2b920127 # v0.2.2
         with:
           db_uri: ${{ secrets.GH_REPORT_STATS_DB_RW_CONNSTR }}
           db_table: 'gh_workflow_stats_serverless'


### PR DESCRIPTION
Do minor upgrade for that action: v0.2.1 -> v0.2.2 with using docker images hosted on ghcr, due to upcoming pull limits from DockerHub