### PR TITLE
Minor tidying

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,12 @@ Using TypeScript? No worries: types are included either way.
 Note: to install with npm for use by another package that declares a dependency on `pg` (node-postgres), use an alias plus an override, which will look something like this in your `package.json`:
 
 ```json
-  ...
   "dependencies": {
     "pg": "npm:@neondatabase/serverless@^1.0.0"
   },
   "overrides": {
     "pg": "npm:@neondatabase/serverless@^1.0.0"
   }
-  ...
 ```
 
 ### Configure it

--- a/tests/browser/browser.test.ts
+++ b/tests/browser/browser.test.ts
@@ -1,8 +1,16 @@
 import { expect, test, assertType } from 'vitest';
 import { server } from '@vitest/browser/context';
-import { neon, Pool, Client, type QueryResult } from '@neondatabase/serverless'; // see package.json: this points to 'file:.'
+import {
+  neon,
+  neonConfig,
+  Pool,
+  Client,
+  type QueryResult,
+} from '@neondatabase/serverless'; // see package.json: this points to 'file:.'
 
 const DATABASE_URL = server.config.env.VITE_NEON_DB_URL!;
+
+neonConfig.disableWarningInBrowsers = true;
 
 test('log version', () => {
   if (typeof navigator !== 'undefined') {

--- a/tests/packages/prisma/http.test.ts
+++ b/tests/packages/prisma/http.test.ts
@@ -1,5 +1,4 @@
 import { expect, test } from 'vitest';
-import { neon } from '@neondatabase/serverless'; // see package.json: this points to 'file:.'
 import { PrismaNeonHTTP } from '@prisma/adapter-neon';
 import { PrismaClient } from '@prisma/client';
 

--- a/tests/packages/prisma/ws.test.ts
+++ b/tests/packages/prisma/ws.test.ts
@@ -1,5 +1,4 @@
 import { expect, test } from 'vitest';
-import { Pool } from '@neondatabase/serverless'; // see package.json: this points to 'file:../../../dist/npm'
 import { PrismaNeon } from '@prisma/adapter-neon';
 import { PrismaClient } from '@prisma/client';
 


### PR DESCRIPTION
This very small PR:

* Removes extraneous imports from Prisma tests
* Sets `disableWarningInBrowsers` to make the browser test output less noisy
* Removes`...` from a JSON snippet in the README, since GitHub highlights this as an error makes (in red reverse-video)