### PR TITLE
Add getConnectionParameters() method to WebSocket client

### DIFF
--- a/index.d.mts
+++ b/index.d.mts
@@ -226,6 +226,13 @@ export declare class Client extends Client_2 {
     config?: (string | ClientConfig) | undefined;
     get neonConfig(): neonConfig;
     constructor(config?: (string | ClientConfig) | undefined);
+    /**
+     * Get connection parameters sent by PostgreSQL server.
+     * Returns a read-only Map containing parameters like 'client_encoding', 'TimeZone', 'server_version', etc.
+     * This is only available for WebSocket connections (Client/Pool), not for HTTP queries.
+     * The Map is populated after connect() completes.
+     */
+    getConnectionParameters(): ReadonlyMap<string, string>;
     connect(): Promise<void>;
     connect(callback: (err?: Error) => void): void;
     _handleAuthSASLContinue(msg: any): Promise<void>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -226,6 +226,13 @@ export declare class Client extends Client_2 {
     config?: (string | ClientConfig) | undefined;
     get neonConfig(): neonConfig;
     constructor(config?: (string | ClientConfig) | undefined);
+    /**
+     * Get connection parameters sent by PostgreSQL server.
+     * Returns a read-only Map containing parameters like 'client_encoding', 'TimeZone', 'server_version', etc.
+     * This is only available for WebSocket connections (Client/Pool), not for HTTP queries.
+     * The Map is populated after connect() completes.
+     */
+    getConnectionParameters(): ReadonlyMap<string, string>;
     connect(): Promise<void>;
     connect(callback: (err?: Error) => void): void;
     _handleAuthSASLContinue(msg: any): Promise<void>;

--- a/index.js
+++ b/index.js
@@ -1307,13 +1307,15 @@ c.dataTypeID)),u=e===!0?r.rows.map(c=>c.map((l,f)=>l===null?null:o[f](l))):r.row
 c.map((l,f)=>[s[f],l===null?null:o[f](l)])));return t?(r.viaNeonFetch=!0,r.rowAsArray=e,r.rows=u,r._parsers=
 o,r._types=i,r):u}a(as,"processQueryResult");async function Fu(r){if(typeof r=="string")return r;if(typeof r==
 "function")try{return await Promise.resolve(r())}catch(e){let t=new de("Error getting auth token.");
-throw e instanceof Error&&(t=new de(`Error getting auth token: ${e.message}`)),t}}a(Fu,"getAuthToken");p();var go=Ae(ct());p();var wo=Ae(ct());var Un=class Un extends wo.Client{constructor(t){super(t);this.config=t}get neonConfig(){return this.
-connection.stream}connect(t){let{neonConfig:n}=this;n.forceDisablePgSSL&&(this.ssl=this.connection.ssl=
-!1),this.ssl&&n.useSecureWebSocket&&console.warn("SSL is enabled for both Postgres (e.g. ?sslmode=re\
-quire in the connection string + forceDisablePgSSL = false) and the WebSocket tunnel (useSecureWebSo\
-cket = true). Double encryption will increase latency and CPU usage. It may be appropriate to disabl\
-e SSL in the Postgres connection parameters or set forceDisablePgSSL = true.");let i=typeof this.config!=
-"string"&&this.config?.host!==void 0||typeof this.config!="string"&&this.config?.connectionString!==
+throw e instanceof Error&&(t=new de(`Error getting auth token: ${e.message}`)),t}}a(Fu,"getAuthToken");p();var go=Ae(ct());p();var wo=Ae(ct());var Un=class Un extends wo.Client{constructor(t){super(t);this.config=t;E(this,"_connectionParameter\
+s",new Map);this.connection.on("parameterStatus",n=>{this._connectionParameters.set(n.parameterName,
+n.parameterValue)})}get neonConfig(){return this.connection.stream}getConnectionParameters(){return this.
+_connectionParameters}connect(t){let{neonConfig:n}=this;n.forceDisablePgSSL&&(this.ssl=this.connection.
+ssl=!1),this.ssl&&n.useSecureWebSocket&&console.warn("SSL is enabled for both Postgres (e.g. ?sslmod\
+e=require in the connection string + forceDisablePgSSL = false) and the WebSocket tunnel (useSecureW\
+ebSocket = true). Double encryption will increase latency and CPU usage. It may be appropriate to di\
+sable SSL in the Postgres connection parameters or set forceDisablePgSSL = true.");let i=typeof this.
+config!="string"&&this.config?.host!==void 0||typeof this.config!="string"&&this.config?.connectionString!==
 void 0||m.env.PGHOST!==void 0,s=m.env.USER??m.env.USERNAME;if(!i&&this.host==="localhost"&&this.user===
 s&&this.database===s&&this.password===null)throw new Error(`No database host or connection string wa\
 s set, and key parameters have default values (host: localhost, user: ${s}, db: ${s}, password: null\

--- a/index.mjs
+++ b/index.mjs
@@ -1305,13 +1305,15 @@ c.dataTypeID)),u=e===!0?r.rows.map(c=>c.map((l,f)=>l===null?null:o[f](l))):r.row
 c.map((l,f)=>[s[f],l===null?null:o[f](l)])));return t?(r.viaNeonFetch=!0,r.rowAsArray=e,r.rows=u,r._parsers=
 o,r._types=i,r):u}a(os,"processQueryResult");async function Fu(r){if(typeof r=="string")return r;if(typeof r==
 "function")try{return await Promise.resolve(r())}catch(e){let t=new be("Error getting auth token.");
-throw e instanceof Error&&(t=new be(`Error getting auth token: ${e.message}`)),t}}a(Fu,"getAuthToken");p();var go=Se(ot());p();var wo=Se(ot());var kn=class kn extends wo.Client{constructor(t){super(t);this.config=t}get neonConfig(){return this.
-connection.stream}connect(t){let{neonConfig:n}=this;n.forceDisablePgSSL&&(this.ssl=this.connection.ssl=
-!1),this.ssl&&n.useSecureWebSocket&&console.warn("SSL is enabled for both Postgres (e.g. ?sslmode=re\
-quire in the connection string + forceDisablePgSSL = false) and the WebSocket tunnel (useSecureWebSo\
-cket = true). Double encryption will increase latency and CPU usage. It may be appropriate to disabl\
-e SSL in the Postgres connection parameters or set forceDisablePgSSL = true.");let i=typeof this.config!=
-"string"&&this.config?.host!==void 0||typeof this.config!="string"&&this.config?.connectionString!==
+throw e instanceof Error&&(t=new be(`Error getting auth token: ${e.message}`)),t}}a(Fu,"getAuthToken");p();var go=Se(ot());p();var wo=Se(ot());var kn=class kn extends wo.Client{constructor(t){super(t);this.config=t;E(this,"_connectionParameter\
+s",new Map);this.connection.on("parameterStatus",n=>{this._connectionParameters.set(n.parameterName,
+n.parameterValue)})}get neonConfig(){return this.connection.stream}getConnectionParameters(){return this.
+_connectionParameters}connect(t){let{neonConfig:n}=this;n.forceDisablePgSSL&&(this.ssl=this.connection.
+ssl=!1),this.ssl&&n.useSecureWebSocket&&console.warn("SSL is enabled for both Postgres (e.g. ?sslmod\
+e=require in the connection string + forceDisablePgSSL = false) and the WebSocket tunnel (useSecureW\
+ebSocket = true). Double encryption will increase latency and CPU usage. It may be appropriate to di\
+sable SSL in the Postgres connection parameters or set forceDisablePgSSL = true.");let i=typeof this.
+config!="string"&&this.config?.host!==void 0||typeof this.config!="string"&&this.config?.connectionString!==
 void 0||m.env.PGHOST!==void 0,s=m.env.USER??m.env.USERNAME;if(!i&&this.host==="localhost"&&this.user===
 s&&this.database===s&&this.password===null)throw new Error(`No database host or connection string wa\
 s set, and key parameters have default values (host: localhost, user: ${s}, db: ${s}, password: null\

--- a/src/client.ts
+++ b/src/client.ts
@@ -20,12 +20,29 @@ export declare interface NeonClient {
  * https://node-postgres.com/apis/client
  */
 export class NeonClient extends Client {
+  private _connectionParameters: Map<string, string> = new Map();
+
   get neonConfig() {
     return this.connection.stream as Socket;
   }
 
   constructor(public config?: string | ClientConfig) {
     super(config);
+
+    // Set up parameterStatus listener to capture connection parameters from PostgreSQL
+    this.connection.on('parameterStatus', (msg: any) => {
+      this._connectionParameters.set(msg.parameterName, msg.parameterValue);
+    });
+  }
+
+  /**
+   * Get connection parameters sent by PostgreSQL server.
+   * Returns a read-only Map containing parameters like 'client_encoding', 'TimeZone', 'server_version', etc.
+   * This is only available for WebSocket connections (Client/Pool), not for HTTP queries.
+   * The Map is populated after connect() completes.
+   */
+  getConnectionParameters(): ReadonlyMap<string, string> {
+    return this._connectionParameters;
   }
 
   override connect(): Promise<void>;

--- a/tests/cli/ws.test.ts
+++ b/tests/cli/ws.test.ts
@@ -174,4 +174,33 @@ describe.each([
       expect((wsResult as any).viaNeonFetch).toBeUndefined();
     });
   }
+
+  test('Client.getConnectionParameters() returns connection parameters', async () => {
+    const client = new WsClient({ connectionString: DB_URL });
+
+    // Before connect, parameters should be empty
+    const paramsBefore = client.getConnectionParameters();
+    expect(paramsBefore.size).toBe(0);
+
+    await client.connect();
+
+    // Run a query to ensure parameters are populated (due to connection pipelining)
+    await client.query('SELECT 1');
+
+    // After query, parameters should be populated
+    const params = client.getConnectionParameters();
+    expect(params.size).toBeGreaterThan(0);
+
+    // Check for common PostgreSQL parameters
+    expect(params.get('client_encoding')).toBeDefined();
+    expect(params.get('server_version')).toBeDefined();
+    expect(params.get('TimeZone')).toBeDefined();
+    expect(params.get('DateStyle')).toBeDefined();
+    expect(params.get('integer_datetimes')).toBeDefined();
+
+    // Verify it's typed as ReadonlyMap (compile-time check)
+    assertType<ReadonlyMap<string, string>>(params);
+
+    await client.end();
+  });
 });


### PR DESCRIPTION
Add a new getConnectionParameters() method to NeonClient that exposes PostgreSQL connection parameters sent by the server during the connection lifecycle.

Added test coverage in tests/cli/ws.test.ts