### PR TITLE
fix: bump @types/pg minimum version to ^8.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@types/node": "^22.15.30",
-    "@types/pg": "^8.8.0"
+    "@types/pg": "^8.11.3"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241230.0",


### PR DESCRIPTION
## Summary

`QueryConfigValues` is imported in `src/pool.ts` but was only added to `@types/pg` in version `8.11.3`. The current dependency constraint `^8.8.0` allows npm to resolve to versions that don't export this type, causing type errors for downstream consumers.

This bumps the minimum to `^8.11.3` to match actual usage.

Fixes #180