### PR TITLE
Inline all TypeScript types for a significant install size reduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.0 (2026-04-09)
+
+Type declarations are now fully inlined (some were previously re-exported from `@types/pg` and `@types/node`). The new types greatly reduce the size of the package with dependencies, and should be compatible in normal usage. The code that is actually run remains unchanged.
+
+A few advanced type-level patterns could be affected. Code that depends on exact type identity with the `@types/pg` exports, that relies on `declare module 'pg'` augmentation flowing through these exports, or that assumes `Buffer`-specific types in places now declared as `Uint8Array` may need updated types.
+
 ## 1.0.2 (2025-09-30)
 
 Update neon.tech references to neon.com domain.

--- a/api-extractor.json
+++ b/api-extractor.json
@@ -2,7 +2,7 @@
   "mainEntryPointFilePath": "build/types/index.d.ts",
   "newlineKind": "lf",
   "enumMemberOrder": "preserve",
-  "bundledPackages": ["subtls"],
+  "bundledPackages": ["subtls", "pg", "events"],
   "dtsRollup": {
     "enabled": true,
     "untrimmedFilePath": "build/generated.d.ts"

--- a/build.sh
+++ b/build.sh
@@ -45,6 +45,12 @@ sed -i.orig -r \
   -e "/^declare global [{]$/,/^[}]$/d" \
   build/types/shims/net/index.d.ts
 
+# strip /// <reference types="node" /> from subtls (added because its upstream
+# .d.ts references node types, but our shims replace those)
+sed -i.orig \
+  -e '/^\/\/\/ <reference types="node" \/>$/d' \
+  node_modules/subtls/index.d.ts
+
 # bundle all types into one file
 npx @microsoft/api-extractor run
 

--- a/index.d.mts
+++ b/index.d.mts
@@ -262,6 +262,7 @@ declare class ClientBase_2 extends EventEmitter {
     getTypeParser(id: PgTypeId, format?: PgTypeFormat): any;
     on(event: 'drain', listener: () => void): this;
     on(event: 'error', listener: (err: Error) => void): this;
+    on(event: 'notice', listener: (notice: NoticeMessage) => void): this;
     on(event: 'notification', listener: (message: Notification) => void): this;
     on(event: 'end', listener: () => void): this;
 }
@@ -904,6 +905,28 @@ export declare class NeonQueryPromise<ArrayMode extends boolean, FullResults ext
     then<TResult1 = T, TResult2 = never>(resolve?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, reject?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
     catch<TResult = never>(reject?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
     finally(finallyFn?: (() => void) | undefined | null): Promise<T>;
+}
+
+declare interface NoticeMessage {
+    readonly name: 'notice';
+    readonly length: number;
+    readonly message: string | undefined;
+    severity: string | undefined;
+    code: string | undefined;
+    detail: string | undefined;
+    hint: string | undefined;
+    position: string | undefined;
+    internalPosition: string | undefined;
+    internalQuery: string | undefined;
+    where: string | undefined;
+    schema: string | undefined;
+    table: string | undefined;
+    column: string | undefined;
+    dataType: string | undefined;
+    constraint: string | undefined;
+    file: string | undefined;
+    line: string | undefined;
+    routine: string | undefined;
 }
 
 export declare interface Notification {

--- a/index.d.mts
+++ b/index.d.mts
@@ -297,7 +297,7 @@ export declare class Connection extends EventEmitter {
 export declare type ConnectionConfig = ClientConfig;
 
 export declare interface CustomTypesConfig {
-    getTypeParser: (id: number, format?: string) => any;
+    getTypeParser: (id: PgTypeId, format?: PgTypeFormat) => any;
 }
 
 export declare class DatabaseError extends Error {
@@ -909,6 +909,16 @@ export declare interface ParameterizedQuery {
     query: string;
     params: any[];
 }
+
+declare type PgTypeFormat = 'text' | 'binary';
+
+declare type PgTypeId =
+| 16 | 17 | 18 | 20 | 21 | 23 | 24 | 25 | 26 | 27 | 28 | 29
+| 114 | 142 | 194 | 210 | 602 | 604 | 650 | 700 | 701 | 702 | 703 | 704
+| 718 | 774 | 790 | 829 | 869 | 1033 | 1042 | 1043 | 1082 | 1083
+| 1114 | 1184 | 1186 | 1266 | 1560 | 1562 | 1700 | 1790 | 2202 | 2203
+| 2204 | 2205 | 2206 | 2950 | 2970 | 3220 | 3361 | 3402 | 3614 | 3615
+| 3642 | 3734 | 3769 | 3802 | 4089 | 4096;
 
 export declare interface Pool {
     Promise: typeof Promise;

--- a/index.d.mts
+++ b/index.d.mts
@@ -249,8 +249,17 @@ declare class ClientBase_2 extends EventEmitter {
     ): void;
     pauseDrain(): void;
     resumeDrain(): void;
+    copyFrom(queryText: string): any;
+    copyTo(queryText: string): any;
     escapeIdentifier(str: string): string;
     escapeLiteral(str: string): string;
+    setTypeParser(id: PgTypeId, parseFn: (value: string) => any): void;
+    setTypeParser(
+    id: PgTypeId,
+    format: PgTypeFormat,
+    parseFn: (value: string) => any,
+    ): void;
+    getTypeParser(id: PgTypeId, format?: PgTypeFormat): any;
     on(event: 'drain', listener: () => void): this;
     on(event: 'error', listener: (err: Error) => void): this;
     on(event: 'notification', listener: (message: Notification) => void): this;
@@ -912,13 +921,7 @@ export declare interface ParameterizedQuery {
 
 declare type PgTypeFormat = 'text' | 'binary';
 
-declare type PgTypeId =
-| 16 | 17 | 18 | 20 | 21 | 23 | 24 | 25 | 26 | 27 | 28 | 29
-| 114 | 142 | 194 | 210 | 602 | 604 | 650 | 700 | 701 | 702 | 703 | 704
-| 718 | 774 | 790 | 829 | 869 | 1033 | 1042 | 1043 | 1082 | 1083
-| 1114 | 1184 | 1186 | 1266 | 1560 | 1562 | 1700 | 1790 | 2202 | 2203
-| 2204 | 2205 | 2206 | 2950 | 2970 | 3220 | 3361 | 3402 | 3614 | 3615
-| 3642 | 3734 | 3769 | 3802 | 4089 | 4096;
+declare type PgTypeId = number;
 
 export declare interface Pool {
     Promise: typeof Promise;
@@ -946,7 +949,7 @@ export declare class Pool extends Pool_2 {
 
 declare class Pool_2 extends EventEmitter {
     constructor(config?: PoolConfig);
-    options: PoolConfig;
+    options: PoolOptions;
     readonly totalCount: number;
     readonly idleCount: number;
     readonly waitingCount: number;
@@ -1015,7 +1018,15 @@ export declare interface PoolConfig extends ClientConfig {
     allowExitOnIdle?: boolean | undefined;
     maxUses?: number | undefined;
     maxLifetimeSeconds?: number | undefined;
-    Client?: (new () => ClientBase_2) | undefined;
+    Client?: (new () => any) | undefined;
+}
+
+declare interface PoolOptions extends PoolConfig {
+    max: number;
+    maxUses: number;
+    allowExitOnIdle: boolean;
+    maxLifetimeSeconds: number;
+    idleTimeoutMillis: number | null;
 }
 
 export declare interface ProcessQueryResultOptions {

--- a/index.d.mts
+++ b/index.d.mts
@@ -1,39 +1,3 @@
-/// <reference types="node" />
-
-import { BindConfig } from 'pg';
-import { Client as Client_2 } from 'pg';
-import type { ClientBase as ClientBase_2 } from 'pg';
-import { ClientConfig } from 'pg';
-import { Connection } from 'pg';
-import { ConnectionConfig } from 'pg';
-import { CustomTypesConfig } from 'pg';
-import { DatabaseError } from 'pg';
-import { Defaults } from 'pg';
-import { defaults } from 'pg';
-import { escapeIdentifier } from 'pg';
-import { escapeLiteral } from 'pg';
-import { EventEmitter } from 'events';
-import { Events } from 'pg';
-import { ExecuteConfig } from 'pg';
-import { FieldDef } from 'pg';
-import { MessageConfig } from 'pg';
-import { Notification } from 'pg';
-import { Pool as Pool_2 } from 'pg';
-import type { PoolClient as PoolClient_2 } from 'pg';
-import { PoolConfig } from 'pg';
-import { Query } from 'pg';
-import { QueryArrayConfig } from 'pg';
-import { QueryArrayResult } from 'pg';
-import { QueryConfig } from 'pg';
-import type { QueryConfigValues } from 'pg';
-import { QueryParse } from 'pg';
-import { QueryResult } from 'pg';
-import { QueryResultBase } from 'pg';
-import { QueryResultRow } from 'pg';
-import { ResultBuilder } from 'pg';
-import { Submittable } from 'pg';
-import { types } from 'pg';
-
 declare const allKeyUsages: readonly ["digitalSignature", "nonRepudiation", "keyEncipherment", "dataEncipherment", "keyAgreement", "keyCertSign", "cRLSign", "encipherOnly", "decipherOnly"];
 
 declare class ASN1Bytes extends Bytes {
@@ -52,7 +16,13 @@ declare class ASN1Bytes extends Bytes {
     expectASN1Null(comment?: string): Promise<void>;
 }
 
-export { BindConfig }
+export declare interface BindConfig {
+    portal?: string | undefined;
+    statement?: string | undefined;
+    binary?: string | undefined;
+    values?: Array<Uint8Array | null | undefined | string> | undefined;
+    valueMapper?: ((param: any, index: number) => any) | undefined;
+}
 
 export declare const _bundleExt: 'js' | 'mjs';
 
@@ -231,19 +201,126 @@ export declare class Client extends Client_2 {
     _handleAuthSASLContinue(msg: any): Promise<void>;
 }
 
+declare class Client_2 extends ClientBase_2 {
+    user?: string | undefined;
+    database?: string | undefined;
+    port: number;
+    host: string;
+    password?: string | undefined;
+    ssl: boolean;
+    readonly connection: Connection;
+    constructor(config?: string | ClientConfig);
+    end(): Promise<void>;
+    end(callback: (err: Error) => void): void;
+}
+
 export declare interface ClientBase extends ClientBase_2 {
     neonConfig: NeonConfigGlobalAndClient;
 }
 
-export { ClientConfig }
+declare class ClientBase_2 extends EventEmitter {
+    constructor(config?: string | ClientConfig);
+    connect(): Promise<void>;
+    connect(callback: (err: Error) => void): void;
+    query<T extends Submittable>(queryStream: T): T;
+    query<R extends any[] = any[], I = any[]>(
+    queryConfig: QueryArrayConfig<I>,
+    values?: QueryConfigValues<I>,
+    ): Promise<QueryArrayResult<R>>;
+    query<R extends QueryResultRow = any, I = any>(
+    queryConfig: QueryConfig<I>,
+    ): Promise<QueryResult<R>>;
+    query<R extends QueryResultRow = any, I = any[]>(
+    queryTextOrConfig: string | QueryConfig<I>,
+    values?: QueryConfigValues<I>,
+    ): Promise<QueryResult<R>>;
+    query<R extends any[] = any[], I = any[]>(
+    queryConfig: QueryArrayConfig<I>,
+    callback: (err: Error, result: QueryArrayResult<R>) => void,
+    ): void;
+    query<R extends QueryResultRow = any, I = any[]>(
+    queryTextOrConfig: string | QueryConfig<I>,
+    callback: (err: Error, result: QueryResult<R>) => void,
+    ): void;
+    query<R extends QueryResultRow = any, I = any[]>(
+    queryText: string,
+    values: QueryConfigValues<I>,
+    callback: (err: Error, result: QueryResult<R>) => void,
+    ): void;
+    pauseDrain(): void;
+    resumeDrain(): void;
+    escapeIdentifier(str: string): string;
+    escapeLiteral(str: string): string;
+    on(event: 'drain', listener: () => void): this;
+    on(event: 'error', listener: (err: Error) => void): this;
+    on(event: 'notification', listener: (message: Notification) => void): this;
+    on(event: 'end', listener: () => void): this;
+}
 
-export { Connection }
+export declare interface ClientConfig {
+    user?: string | undefined;
+    database?: string | undefined;
+    password?: string | (() => string | Promise<string>) | undefined;
+    port?: number | undefined;
+    host?: string | undefined;
+    connectionString?: string | undefined;
+    keepAlive?: boolean | undefined;
+    stream?: (() => any) | undefined;
+    statement_timeout?: false | number | undefined;
+    ssl?: boolean | object | undefined;
+    query_timeout?: number | undefined;
+    lock_timeout?: number | undefined;
+    keepAliveInitialDelayMillis?: number | undefined;
+    idle_in_transaction_session_timeout?: number | undefined;
+    application_name?: string | undefined;
+    fallback_application_name?: string | undefined;
+    connectionTimeoutMillis?: number | undefined;
+    types?: CustomTypesConfig | undefined;
+    options?: string | undefined;
+    client_encoding?: string | undefined;
+}
 
-export { ConnectionConfig }
+export declare class Connection extends EventEmitter {
+    readonly stream: any;
+    constructor(config?: ConnectionConfig);
+    bind(config: BindConfig | null, more: boolean): void;
+    execute(config: ExecuteConfig | null, more: boolean): void;
+    parse(query: QueryParse, more: boolean): void;
+    query(text: string): void;
+    describe(msg: MessageConfig, more: boolean): void;
+    close(msg: MessageConfig, more: boolean): void;
+    flush(): void;
+    sync(): void;
+    end(): void;
+}
 
-export { CustomTypesConfig }
+export declare type ConnectionConfig = ClientConfig;
 
-export { DatabaseError }
+export declare interface CustomTypesConfig {
+    getTypeParser: (id: number, format?: string) => any;
+}
+
+export declare class DatabaseError extends Error {
+    readonly length: number;
+    readonly name: string;
+    severity: string | undefined;
+    code: string | undefined;
+    detail: string | undefined;
+    hint: string | undefined;
+    position: string | undefined;
+    internalPosition: string | undefined;
+    internalQuery: string | undefined;
+    where: string | undefined;
+    schema: string | undefined;
+    table: string | undefined;
+    column: string | undefined;
+    dataType: string | undefined;
+    constraint: string | undefined;
+    file: string | undefined;
+    line: string | undefined;
+    routine: string | undefined;
+    constructor(message: string, length: number, name: string);
+}
 
 declare interface DataRequest {
     bytes: number;
@@ -251,25 +328,84 @@ declare interface DataRequest {
     readMode: ReadMode;
 }
 
-export { Defaults }
+export declare interface Defaults extends ClientConfig {
+    poolSize?: number | undefined;
+    poolIdleTimeout?: number | undefined;
+    reapIntervalMillis?: number | undefined;
+    binary?: boolean | undefined;
+    parseInt8?: boolean | undefined;
+    parseInputDatesAsUTC?: boolean | undefined;
+}
 
-export { defaults }
+export declare const defaults: Defaults & ClientConfig;
 
 declare type DistinguishedName = Record<string, string | string[]>;
 
-export { escapeIdentifier }
+export declare function escapeIdentifier(str: string): string;
 
-export { escapeLiteral }
+export declare function escapeLiteral(str: string): string;
 
-export { Events }
+declare class EventEmitter {
+    addListener(
+    eventName: string | symbol,
+    listener: (...args: any[]) => void,
+    ): this;
+    on(
+    eventName: string | symbol,
+    listener: (...args: any[]) => void,
+    ): this;
+    once(
+    eventName: string | symbol,
+    listener: (...args: any[]) => void,
+    ): this;
+    removeListener(
+    eventName: string | symbol,
+    listener: (...args: any[]) => void,
+    ): this;
+    off(
+    eventName: string | symbol,
+    listener: (...args: any[]) => void,
+    ): this;
+    removeAllListeners(event?: string | symbol): this;
+    setMaxListeners(n: number): this;
+    getMaxListeners(): number;
+    listeners(eventName: string | symbol): Function[];
+    rawListeners(eventName: string | symbol): Function[];
+    emit(eventName: string | symbol, ...args: any[]): boolean;
+    listenerCount(eventName: string | symbol): number;
+    prependListener(
+    eventName: string | symbol,
+    listener: (...args: any[]) => void,
+    ): this;
+    prependOnceListener(
+    eventName: string | symbol,
+    listener: (...args: any[]) => void,
+    ): this;
+    eventNames(): Array<string | symbol>;
+}
 
-export { ExecuteConfig }
+export declare class Events extends EventEmitter {
+    on(event: 'error', listener: (err: Error, client: Client_2) => void): this;
+}
+
+export declare interface ExecuteConfig {
+    portal?: string | undefined;
+    rows?: string | undefined;
+}
 
 export declare interface FetchEndpointOptions {
     jwtAuth?: boolean;
 }
 
-export { FieldDef }
+export declare interface FieldDef {
+    name: string;
+    tableID: number;
+    columnID: number;
+    dataTypeID: number;
+    dataTypeSize: number;
+    dataTypeModifier: number;
+    format: string;
+}
 
 export declare interface FullQueryResults<ArrayMode extends boolean> {
     fields: FieldDef[];
@@ -348,7 +484,10 @@ export declare interface HTTPTransactionOptions<ArrayMode extends boolean, FullR
     deferrable?: boolean;
 }
 
-export { MessageConfig }
+export declare interface MessageConfig {
+    type: string;
+    name?: string | undefined;
+}
 
 /**
  * Returns an async tagged-template function that runs a single SQL query (no
@@ -634,8 +773,8 @@ export declare class neonConfig extends EventEmitter {
     startTls(host: string): Promise<void>;
     tlsReadLoop(): Promise<void>;
     rawWrite(data: Uint8Array): void;
-    write(data: Buffer | string, encoding?: string, callback?: (err?: any) => void): boolean;
-    end(data?: Buffer | string, encoding?: string, callback?: () => void): this;
+    write(data: Uint8Array | string, encoding?: string, callback?: (err?: any) => void): boolean;
+    end(data?: Uint8Array | string, encoding?: string, callback?: () => void): this;
     destroy(): this;
 }
 
@@ -758,7 +897,11 @@ export declare class NeonQueryPromise<ArrayMode extends boolean, FullResults ext
     finally(finallyFn?: (() => void) | undefined | null): Promise<T>;
 }
 
-export { Notification }
+export declare interface Notification {
+    processId: number;
+    channel: string;
+    payload?: string | undefined;
+}
 
 declare type OID = string;
 
@@ -791,11 +934,79 @@ export declare class Pool extends Pool_2 {
     query<R extends QueryResultRow = any, I = any[]>(queryText: string, values: QueryConfigValues<I>, callback: (err: Error, result: QueryResult<R>) => void): void;
 }
 
+declare class Pool_2 extends EventEmitter {
+    constructor(config?: PoolConfig);
+    options: PoolConfig;
+    readonly totalCount: number;
+    readonly idleCount: number;
+    readonly waitingCount: number;
+    readonly expiredCount: number;
+    readonly ending: boolean;
+    readonly ended: boolean;
+    connect(): Promise<PoolClient_2>;
+    connect(
+    callback: (
+    err: Error | undefined,
+    client: PoolClient_2 | undefined,
+    done: (release?: any) => void,
+    ) => void,
+    ): void;
+    end(): Promise<void>;
+    end(callback: () => void): void;
+    query<T extends Submittable>(queryStream: T): T;
+    query<R extends any[] = any[], I = any[]>(
+    queryConfig: QueryArrayConfig<I>,
+    values?: QueryConfigValues<I>,
+    ): Promise<QueryArrayResult<R>>;
+    query<R extends QueryResultRow = any, I = any[]>(
+    queryConfig: QueryConfig<I>,
+    ): Promise<QueryResult<R>>;
+    query<R extends QueryResultRow = any, I = any[]>(
+    queryTextOrConfig: string | QueryConfig<I>,
+    values?: QueryConfigValues<I>,
+    ): Promise<QueryResult<R>>;
+    query<R extends any[] = any[], I = any[]>(
+    queryConfig: QueryArrayConfig<I>,
+    callback: (err: Error, result: QueryArrayResult<R>) => void,
+    ): void;
+    query<R extends QueryResultRow = any, I = any[]>(
+    queryTextOrConfig: string | QueryConfig<I>,
+    callback: (err: Error, result: QueryResult<R>) => void,
+    ): void;
+    query<R extends QueryResultRow = any, I = any[]>(
+    queryText: string,
+    values: QueryConfigValues<I>,
+    callback: (err: Error, result: QueryResult<R>) => void,
+    ): void;
+    on(
+    event: 'release' | 'error',
+    listener: (err: Error, client: PoolClient_2) => void,
+    ): this;
+    on(
+    event: 'connect' | 'acquire' | 'remove',
+    listener: (client: PoolClient_2) => void,
+    ): this;
+}
+
 export declare interface PoolClient extends PoolClient_2 {
     neonConfig: NeonConfigGlobalAndClient;
 }
 
-export { PoolConfig }
+declare interface PoolClient_2 extends ClientBase_2 {
+    release(err?: Error | boolean): void;
+}
+
+export declare interface PoolConfig extends ClientConfig {
+    max?: number | undefined;
+    min?: number | undefined;
+    idleTimeoutMillis?: number | undefined | null;
+    log?: ((...messages: any[]) => void) | undefined;
+    Promise?: PromiseConstructorLike | undefined;
+    allowExitOnIdle?: boolean | undefined;
+    maxUses?: number | undefined;
+    maxLifetimeSeconds?: number | undefined;
+    Client?: (new () => ClientBase_2) | undefined;
+}
 
 export declare interface ProcessQueryResultOptions {
     arrayMode: boolean;
@@ -803,21 +1014,62 @@ export declare interface ProcessQueryResultOptions {
     types?: CustomTypesConfig;
 }
 
-export { Query }
+export declare class Query<R extends QueryResultRow = any, I extends any[] = any>
+extends EventEmitter
+implements Submittable
+    {
+    constructor(
+    queryTextOrConfig?: string | QueryConfig<I>,
+    values?: QueryConfigValues<I>,
+    );
+    submit: (connection: Connection) => void;
+    on(
+    event: 'row',
+    listener: (row: R, result?: ResultBuilder<R>) => void,
+    ): this;
+    on(event: 'error', listener: (err: Error) => void): this;
+    on(event: 'end', listener: (result: ResultBuilder<R>) => void): this;
+}
 
-export { QueryArrayConfig }
+export declare interface QueryArrayConfig<I = any[]> extends QueryConfig<I> {
+    rowMode: 'array';
+}
 
-export { QueryArrayResult }
+export declare interface QueryArrayResult<R extends any[] = any[]>
+extends QueryResultBase {
+    rows: R[];
+}
 
-export { QueryConfig }
+export declare interface QueryConfig<I = any[]> {
+    name?: string | undefined;
+    text: string;
+    values?: QueryConfigValues<I>;
+    types?: CustomTypesConfig | undefined;
+}
 
-export { QueryParse }
+declare type QueryConfigValues<T> = T extends Array<infer U> ? T : never;
 
-export { QueryResult }
+export declare interface QueryParse {
+    name: string;
+    text: string;
+    types: string[];
+}
 
-export { QueryResultBase }
+export declare interface QueryResult<R extends QueryResultRow = any>
+extends QueryResultBase {
+    rows: R[];
+}
 
-export { QueryResultRow }
+export declare interface QueryResultBase {
+    command: string;
+    rowCount: number | null;
+    oid: number;
+    fields: FieldDef[];
+}
+
+export declare interface QueryResultRow {
+    [column: string]: any;
+}
 
 export declare type QueryRows<ArrayMode extends boolean> = ArrayMode extends true ? any[][] : Record<string, any>[];
 
@@ -837,7 +1089,10 @@ declare abstract class ReadQueue {
     read(bytes: number, readMode?: ReadMode): Promise<Uint8Array | undefined>;
 }
 
-export { ResultBuilder }
+export declare interface ResultBuilder<R extends QueryResultRow = any>
+extends QueryResult<R> {
+    addRow(row: R): void;
+}
 
 declare type RootCertsData = Uint8Array;
 
@@ -877,7 +1132,9 @@ export declare function startTls(host: string, rootCertsDatabase: RootCertsDatab
     readonly userCert: Cert;
 }>;
 
-export { Submittable }
+export declare interface Submittable {
+    submit: (connection: Connection) => void;
+}
 
 export declare interface subtls {
     startTls: typeof startTls;
@@ -890,7 +1147,17 @@ export declare class TrustedCert extends Cert {
     static findInDatabase(subjectOrSubjectKeyId: DistinguishedName | string, db: RootCertsDatabase): Promise<Cert | undefined>;
 }
 
-export { types }
+export declare const types: {
+    setTypeParser(id: number, parseFn: (value: string) => any): void;
+    setTypeParser(
+    id: number,
+    format: 'text' | 'binary',
+    parseFn: (value: string) => any,
+    ): void;
+    getTypeParser(id: number, format?: 'text' | 'binary'): any;
+    arrayParser(source: string, transform: (entry: any) => any): any[];
+    builtins: { [key: string]: number };
+};
 
 export declare class UnsafeRawSql {
     sql: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -262,6 +262,7 @@ declare class ClientBase_2 extends EventEmitter {
     getTypeParser(id: PgTypeId, format?: PgTypeFormat): any;
     on(event: 'drain', listener: () => void): this;
     on(event: 'error', listener: (err: Error) => void): this;
+    on(event: 'notice', listener: (notice: NoticeMessage) => void): this;
     on(event: 'notification', listener: (message: Notification) => void): this;
     on(event: 'end', listener: () => void): this;
 }
@@ -904,6 +905,28 @@ export declare class NeonQueryPromise<ArrayMode extends boolean, FullResults ext
     then<TResult1 = T, TResult2 = never>(resolve?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, reject?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
     catch<TResult = never>(reject?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
     finally(finallyFn?: (() => void) | undefined | null): Promise<T>;
+}
+
+declare interface NoticeMessage {
+    readonly name: 'notice';
+    readonly length: number;
+    readonly message: string | undefined;
+    severity: string | undefined;
+    code: string | undefined;
+    detail: string | undefined;
+    hint: string | undefined;
+    position: string | undefined;
+    internalPosition: string | undefined;
+    internalQuery: string | undefined;
+    where: string | undefined;
+    schema: string | undefined;
+    table: string | undefined;
+    column: string | undefined;
+    dataType: string | undefined;
+    constraint: string | undefined;
+    file: string | undefined;
+    line: string | undefined;
+    routine: string | undefined;
 }
 
 export declare interface Notification {

--- a/index.d.ts
+++ b/index.d.ts
@@ -297,7 +297,7 @@ export declare class Connection extends EventEmitter {
 export declare type ConnectionConfig = ClientConfig;
 
 export declare interface CustomTypesConfig {
-    getTypeParser: (id: number, format?: string) => any;
+    getTypeParser: (id: PgTypeId, format?: PgTypeFormat) => any;
 }
 
 export declare class DatabaseError extends Error {
@@ -909,6 +909,16 @@ export declare interface ParameterizedQuery {
     query: string;
     params: any[];
 }
+
+declare type PgTypeFormat = 'text' | 'binary';
+
+declare type PgTypeId =
+| 16 | 17 | 18 | 20 | 21 | 23 | 24 | 25 | 26 | 27 | 28 | 29
+| 114 | 142 | 194 | 210 | 602 | 604 | 650 | 700 | 701 | 702 | 703 | 704
+| 718 | 774 | 790 | 829 | 869 | 1033 | 1042 | 1043 | 1082 | 1083
+| 1114 | 1184 | 1186 | 1266 | 1560 | 1562 | 1700 | 1790 | 2202 | 2203
+| 2204 | 2205 | 2206 | 2950 | 2970 | 3220 | 3361 | 3402 | 3614 | 3615
+| 3642 | 3734 | 3769 | 3802 | 4089 | 4096;
 
 export declare interface Pool {
     Promise: typeof Promise;

--- a/index.d.ts
+++ b/index.d.ts
@@ -249,8 +249,17 @@ declare class ClientBase_2 extends EventEmitter {
     ): void;
     pauseDrain(): void;
     resumeDrain(): void;
+    copyFrom(queryText: string): any;
+    copyTo(queryText: string): any;
     escapeIdentifier(str: string): string;
     escapeLiteral(str: string): string;
+    setTypeParser(id: PgTypeId, parseFn: (value: string) => any): void;
+    setTypeParser(
+    id: PgTypeId,
+    format: PgTypeFormat,
+    parseFn: (value: string) => any,
+    ): void;
+    getTypeParser(id: PgTypeId, format?: PgTypeFormat): any;
     on(event: 'drain', listener: () => void): this;
     on(event: 'error', listener: (err: Error) => void): this;
     on(event: 'notification', listener: (message: Notification) => void): this;
@@ -912,13 +921,7 @@ export declare interface ParameterizedQuery {
 
 declare type PgTypeFormat = 'text' | 'binary';
 
-declare type PgTypeId =
-| 16 | 17 | 18 | 20 | 21 | 23 | 24 | 25 | 26 | 27 | 28 | 29
-| 114 | 142 | 194 | 210 | 602 | 604 | 650 | 700 | 701 | 702 | 703 | 704
-| 718 | 774 | 790 | 829 | 869 | 1033 | 1042 | 1043 | 1082 | 1083
-| 1114 | 1184 | 1186 | 1266 | 1560 | 1562 | 1700 | 1790 | 2202 | 2203
-| 2204 | 2205 | 2206 | 2950 | 2970 | 3220 | 3361 | 3402 | 3614 | 3615
-| 3642 | 3734 | 3769 | 3802 | 4089 | 4096;
+declare type PgTypeId = number;
 
 export declare interface Pool {
     Promise: typeof Promise;
@@ -946,7 +949,7 @@ export declare class Pool extends Pool_2 {
 
 declare class Pool_2 extends EventEmitter {
     constructor(config?: PoolConfig);
-    options: PoolConfig;
+    options: PoolOptions;
     readonly totalCount: number;
     readonly idleCount: number;
     readonly waitingCount: number;
@@ -1015,7 +1018,15 @@ export declare interface PoolConfig extends ClientConfig {
     allowExitOnIdle?: boolean | undefined;
     maxUses?: number | undefined;
     maxLifetimeSeconds?: number | undefined;
-    Client?: (new () => ClientBase_2) | undefined;
+    Client?: (new () => any) | undefined;
+}
+
+declare interface PoolOptions extends PoolConfig {
+    max: number;
+    maxUses: number;
+    allowExitOnIdle: boolean;
+    maxLifetimeSeconds: number;
+    idleTimeoutMillis: number | null;
 }
 
 export declare interface ProcessQueryResultOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,39 +1,3 @@
-/// <reference types="node" />
-
-import { BindConfig } from 'pg';
-import { Client as Client_2 } from 'pg';
-import type { ClientBase as ClientBase_2 } from 'pg';
-import { ClientConfig } from 'pg';
-import { Connection } from 'pg';
-import { ConnectionConfig } from 'pg';
-import { CustomTypesConfig } from 'pg';
-import { DatabaseError } from 'pg';
-import { Defaults } from 'pg';
-import { defaults } from 'pg';
-import { escapeIdentifier } from 'pg';
-import { escapeLiteral } from 'pg';
-import { EventEmitter } from 'events';
-import { Events } from 'pg';
-import { ExecuteConfig } from 'pg';
-import { FieldDef } from 'pg';
-import { MessageConfig } from 'pg';
-import { Notification } from 'pg';
-import { Pool as Pool_2 } from 'pg';
-import type { PoolClient as PoolClient_2 } from 'pg';
-import { PoolConfig } from 'pg';
-import { Query } from 'pg';
-import { QueryArrayConfig } from 'pg';
-import { QueryArrayResult } from 'pg';
-import { QueryConfig } from 'pg';
-import type { QueryConfigValues } from 'pg';
-import { QueryParse } from 'pg';
-import { QueryResult } from 'pg';
-import { QueryResultBase } from 'pg';
-import { QueryResultRow } from 'pg';
-import { ResultBuilder } from 'pg';
-import { Submittable } from 'pg';
-import { types } from 'pg';
-
 declare const allKeyUsages: readonly ["digitalSignature", "nonRepudiation", "keyEncipherment", "dataEncipherment", "keyAgreement", "keyCertSign", "cRLSign", "encipherOnly", "decipherOnly"];
 
 declare class ASN1Bytes extends Bytes {
@@ -52,7 +16,13 @@ declare class ASN1Bytes extends Bytes {
     expectASN1Null(comment?: string): Promise<void>;
 }
 
-export { BindConfig }
+export declare interface BindConfig {
+    portal?: string | undefined;
+    statement?: string | undefined;
+    binary?: string | undefined;
+    values?: Array<Uint8Array | null | undefined | string> | undefined;
+    valueMapper?: ((param: any, index: number) => any) | undefined;
+}
 
 export declare const _bundleExt: 'js' | 'mjs';
 
@@ -231,19 +201,126 @@ export declare class Client extends Client_2 {
     _handleAuthSASLContinue(msg: any): Promise<void>;
 }
 
+declare class Client_2 extends ClientBase_2 {
+    user?: string | undefined;
+    database?: string | undefined;
+    port: number;
+    host: string;
+    password?: string | undefined;
+    ssl: boolean;
+    readonly connection: Connection;
+    constructor(config?: string | ClientConfig);
+    end(): Promise<void>;
+    end(callback: (err: Error) => void): void;
+}
+
 export declare interface ClientBase extends ClientBase_2 {
     neonConfig: NeonConfigGlobalAndClient;
 }
 
-export { ClientConfig }
+declare class ClientBase_2 extends EventEmitter {
+    constructor(config?: string | ClientConfig);
+    connect(): Promise<void>;
+    connect(callback: (err: Error) => void): void;
+    query<T extends Submittable>(queryStream: T): T;
+    query<R extends any[] = any[], I = any[]>(
+    queryConfig: QueryArrayConfig<I>,
+    values?: QueryConfigValues<I>,
+    ): Promise<QueryArrayResult<R>>;
+    query<R extends QueryResultRow = any, I = any>(
+    queryConfig: QueryConfig<I>,
+    ): Promise<QueryResult<R>>;
+    query<R extends QueryResultRow = any, I = any[]>(
+    queryTextOrConfig: string | QueryConfig<I>,
+    values?: QueryConfigValues<I>,
+    ): Promise<QueryResult<R>>;
+    query<R extends any[] = any[], I = any[]>(
+    queryConfig: QueryArrayConfig<I>,
+    callback: (err: Error, result: QueryArrayResult<R>) => void,
+    ): void;
+    query<R extends QueryResultRow = any, I = any[]>(
+    queryTextOrConfig: string | QueryConfig<I>,
+    callback: (err: Error, result: QueryResult<R>) => void,
+    ): void;
+    query<R extends QueryResultRow = any, I = any[]>(
+    queryText: string,
+    values: QueryConfigValues<I>,
+    callback: (err: Error, result: QueryResult<R>) => void,
+    ): void;
+    pauseDrain(): void;
+    resumeDrain(): void;
+    escapeIdentifier(str: string): string;
+    escapeLiteral(str: string): string;
+    on(event: 'drain', listener: () => void): this;
+    on(event: 'error', listener: (err: Error) => void): this;
+    on(event: 'notification', listener: (message: Notification) => void): this;
+    on(event: 'end', listener: () => void): this;
+}
 
-export { Connection }
+export declare interface ClientConfig {
+    user?: string | undefined;
+    database?: string | undefined;
+    password?: string | (() => string | Promise<string>) | undefined;
+    port?: number | undefined;
+    host?: string | undefined;
+    connectionString?: string | undefined;
+    keepAlive?: boolean | undefined;
+    stream?: (() => any) | undefined;
+    statement_timeout?: false | number | undefined;
+    ssl?: boolean | object | undefined;
+    query_timeout?: number | undefined;
+    lock_timeout?: number | undefined;
+    keepAliveInitialDelayMillis?: number | undefined;
+    idle_in_transaction_session_timeout?: number | undefined;
+    application_name?: string | undefined;
+    fallback_application_name?: string | undefined;
+    connectionTimeoutMillis?: number | undefined;
+    types?: CustomTypesConfig | undefined;
+    options?: string | undefined;
+    client_encoding?: string | undefined;
+}
 
-export { ConnectionConfig }
+export declare class Connection extends EventEmitter {
+    readonly stream: any;
+    constructor(config?: ConnectionConfig);
+    bind(config: BindConfig | null, more: boolean): void;
+    execute(config: ExecuteConfig | null, more: boolean): void;
+    parse(query: QueryParse, more: boolean): void;
+    query(text: string): void;
+    describe(msg: MessageConfig, more: boolean): void;
+    close(msg: MessageConfig, more: boolean): void;
+    flush(): void;
+    sync(): void;
+    end(): void;
+}
 
-export { CustomTypesConfig }
+export declare type ConnectionConfig = ClientConfig;
 
-export { DatabaseError }
+export declare interface CustomTypesConfig {
+    getTypeParser: (id: number, format?: string) => any;
+}
+
+export declare class DatabaseError extends Error {
+    readonly length: number;
+    readonly name: string;
+    severity: string | undefined;
+    code: string | undefined;
+    detail: string | undefined;
+    hint: string | undefined;
+    position: string | undefined;
+    internalPosition: string | undefined;
+    internalQuery: string | undefined;
+    where: string | undefined;
+    schema: string | undefined;
+    table: string | undefined;
+    column: string | undefined;
+    dataType: string | undefined;
+    constraint: string | undefined;
+    file: string | undefined;
+    line: string | undefined;
+    routine: string | undefined;
+    constructor(message: string, length: number, name: string);
+}
 
 declare interface DataRequest {
     bytes: number;
@@ -251,25 +328,84 @@ declare interface DataRequest {
     readMode: ReadMode;
 }
 
-export { Defaults }
+export declare interface Defaults extends ClientConfig {
+    poolSize?: number | undefined;
+    poolIdleTimeout?: number | undefined;
+    reapIntervalMillis?: number | undefined;
+    binary?: boolean | undefined;
+    parseInt8?: boolean | undefined;
+    parseInputDatesAsUTC?: boolean | undefined;
+}
 
-export { defaults }
+export declare const defaults: Defaults & ClientConfig;
 
 declare type DistinguishedName = Record<string, string | string[]>;
 
-export { escapeIdentifier }
+export declare function escapeIdentifier(str: string): string;
 
-export { escapeLiteral }
+export declare function escapeLiteral(str: string): string;
 
-export { Events }
+declare class EventEmitter {
+    addListener(
+    eventName: string | symbol,
+    listener: (...args: any[]) => void,
+    ): this;
+    on(
+    eventName: string | symbol,
+    listener: (...args: any[]) => void,
+    ): this;
+    once(
+    eventName: string | symbol,
+    listener: (...args: any[]) => void,
+    ): this;
+    removeListener(
+    eventName: string | symbol,
+    listener: (...args: any[]) => void,
+    ): this;
+    off(
+    eventName: string | symbol,
+    listener: (...args: any[]) => void,
+    ): this;
+    removeAllListeners(event?: string | symbol): this;
+    setMaxListeners(n: number): this;
+    getMaxListeners(): number;
+    listeners(eventName: string | symbol): Function[];
+    rawListeners(eventName: string | symbol): Function[];
+    emit(eventName: string | symbol, ...args: any[]): boolean;
+    listenerCount(eventName: string | symbol): number;
+    prependListener(
+    eventName: string | symbol,
+    listener: (...args: any[]) => void,
+    ): this;
+    prependOnceListener(
+    eventName: string | symbol,
+    listener: (...args: any[]) => void,
+    ): this;
+    eventNames(): Array<string | symbol>;
+}
 
-export { ExecuteConfig }
+export declare class Events extends EventEmitter {
+    on(event: 'error', listener: (err: Error, client: Client_2) => void): this;
+}
+
+export declare interface ExecuteConfig {
+    portal?: string | undefined;
+    rows?: string | undefined;
+}
 
 export declare interface FetchEndpointOptions {
     jwtAuth?: boolean;
 }
 
-export { FieldDef }
+export declare interface FieldDef {
+    name: string;
+    tableID: number;
+    columnID: number;
+    dataTypeID: number;
+    dataTypeSize: number;
+    dataTypeModifier: number;
+    format: string;
+}
 
 export declare interface FullQueryResults<ArrayMode extends boolean> {
     fields: FieldDef[];
@@ -348,7 +484,10 @@ export declare interface HTTPTransactionOptions<ArrayMode extends boolean, FullR
     deferrable?: boolean;
 }
 
-export { MessageConfig }
+export declare interface MessageConfig {
+    type: string;
+    name?: string | undefined;
+}
 
 /**
  * Returns an async tagged-template function that runs a single SQL query (no
@@ -634,8 +773,8 @@ export declare class neonConfig extends EventEmitter {
     startTls(host: string): Promise<void>;
     tlsReadLoop(): Promise<void>;
     rawWrite(data: Uint8Array): void;
-    write(data: Buffer | string, encoding?: string, callback?: (err?: any) => void): boolean;
-    end(data?: Buffer | string, encoding?: string, callback?: () => void): this;
+    write(data: Uint8Array | string, encoding?: string, callback?: (err?: any) => void): boolean;
+    end(data?: Uint8Array | string, encoding?: string, callback?: () => void): this;
     destroy(): this;
 }
 
@@ -758,7 +897,11 @@ export declare class NeonQueryPromise<ArrayMode extends boolean, FullResults ext
     finally(finallyFn?: (() => void) | undefined | null): Promise<T>;
 }
 
-export { Notification }
+export declare interface Notification {
+    processId: number;
+    channel: string;
+    payload?: string | undefined;
+}
 
 declare type OID = string;
 
@@ -791,11 +934,79 @@ export declare class Pool extends Pool_2 {
     query<R extends QueryResultRow = any, I = any[]>(queryText: string, values: QueryConfigValues<I>, callback: (err: Error, result: QueryResult<R>) => void): void;
 }
 
+declare class Pool_2 extends EventEmitter {
+    constructor(config?: PoolConfig);
+    options: PoolConfig;
+    readonly totalCount: number;
+    readonly idleCount: number;
+    readonly waitingCount: number;
+    readonly expiredCount: number;
+    readonly ending: boolean;
+    readonly ended: boolean;
+    connect(): Promise<PoolClient_2>;
+    connect(
+    callback: (
+    err: Error | undefined,
+    client: PoolClient_2 | undefined,
+    done: (release?: any) => void,
+    ) => void,
+    ): void;
+    end(): Promise<void>;
+    end(callback: () => void): void;
+    query<T extends Submittable>(queryStream: T): T;
+    query<R extends any[] = any[], I = any[]>(
+    queryConfig: QueryArrayConfig<I>,
+    values?: QueryConfigValues<I>,
+    ): Promise<QueryArrayResult<R>>;
+    query<R extends QueryResultRow = any, I = any[]>(
+    queryConfig: QueryConfig<I>,
+    ): Promise<QueryResult<R>>;
+    query<R extends QueryResultRow = any, I = any[]>(
+    queryTextOrConfig: string | QueryConfig<I>,
+    values?: QueryConfigValues<I>,
+    ): Promise<QueryResult<R>>;
+    query<R extends any[] = any[], I = any[]>(
+    queryConfig: QueryArrayConfig<I>,
+    callback: (err: Error, result: QueryArrayResult<R>) => void,
+    ): void;
+    query<R extends QueryResultRow = any, I = any[]>(
+    queryTextOrConfig: string | QueryConfig<I>,
+    callback: (err: Error, result: QueryResult<R>) => void,
+    ): void;
+    query<R extends QueryResultRow = any, I = any[]>(
+    queryText: string,
+    values: QueryConfigValues<I>,
+    callback: (err: Error, result: QueryResult<R>) => void,
+    ): void;
+    on(
+    event: 'release' | 'error',
+    listener: (err: Error, client: PoolClient_2) => void,
+    ): this;
+    on(
+    event: 'connect' | 'acquire' | 'remove',
+    listener: (client: PoolClient_2) => void,
+    ): this;
+}
+
 export declare interface PoolClient extends PoolClient_2 {
     neonConfig: NeonConfigGlobalAndClient;
 }
 
-export { PoolConfig }
+declare interface PoolClient_2 extends ClientBase_2 {
+    release(err?: Error | boolean): void;
+}
+
+export declare interface PoolConfig extends ClientConfig {
+    max?: number | undefined;
+    min?: number | undefined;
+    idleTimeoutMillis?: number | undefined | null;
+    log?: ((...messages: any[]) => void) | undefined;
+    Promise?: PromiseConstructorLike | undefined;
+    allowExitOnIdle?: boolean | undefined;
+    maxUses?: number | undefined;
+    maxLifetimeSeconds?: number | undefined;
+    Client?: (new () => ClientBase_2) | undefined;
+}
 
 export declare interface ProcessQueryResultOptions {
     arrayMode: boolean;
@@ -803,21 +1014,62 @@ export declare interface ProcessQueryResultOptions {
     types?: CustomTypesConfig;
 }
 
-export { Query }
+export declare class Query<R extends QueryResultRow = any, I extends any[] = any>
+extends EventEmitter
+implements Submittable
+    {
+    constructor(
+    queryTextOrConfig?: string | QueryConfig<I>,
+    values?: QueryConfigValues<I>,
+    );
+    submit: (connection: Connection) => void;
+    on(
+    event: 'row',
+    listener: (row: R, result?: ResultBuilder<R>) => void,
+    ): this;
+    on(event: 'error', listener: (err: Error) => void): this;
+    on(event: 'end', listener: (result: ResultBuilder<R>) => void): this;
+}
 
-export { QueryArrayConfig }
+export declare interface QueryArrayConfig<I = any[]> extends QueryConfig<I> {
+    rowMode: 'array';
+}
 
-export { QueryArrayResult }
+export declare interface QueryArrayResult<R extends any[] = any[]>
+extends QueryResultBase {
+    rows: R[];
+}
 
-export { QueryConfig }
+export declare interface QueryConfig<I = any[]> {
+    name?: string | undefined;
+    text: string;
+    values?: QueryConfigValues<I>;
+    types?: CustomTypesConfig | undefined;
+}
 
-export { QueryParse }
+declare type QueryConfigValues<T> = T extends Array<infer U> ? T : never;
 
-export { QueryResult }
+export declare interface QueryParse {
+    name: string;
+    text: string;
+    types: string[];
+}
 
-export { QueryResultBase }
+export declare interface QueryResult<R extends QueryResultRow = any>
+extends QueryResultBase {
+    rows: R[];
+}
 
-export { QueryResultRow }
+export declare interface QueryResultBase {
+    command: string;
+    rowCount: number | null;
+    oid: number;
+    fields: FieldDef[];
+}
+
+export declare interface QueryResultRow {
+    [column: string]: any;
+}
 
 export declare type QueryRows<ArrayMode extends boolean> = ArrayMode extends true ? any[][] : Record<string, any>[];
 
@@ -837,7 +1089,10 @@ declare abstract class ReadQueue {
     read(bytes: number, readMode?: ReadMode): Promise<Uint8Array | undefined>;
 }
 
-export { ResultBuilder }
+export declare interface ResultBuilder<R extends QueryResultRow = any>
+extends QueryResult<R> {
+    addRow(row: R): void;
+}
 
 declare type RootCertsData = Uint8Array;
 
@@ -877,7 +1132,9 @@ export declare function startTls(host: string, rootCertsDatabase: RootCertsDatab
     readonly userCert: Cert;
 }>;
 
-export { Submittable }
+export declare interface Submittable {
+    submit: (connection: Connection) => void;
+}
 
 export declare interface subtls {
     startTls: typeof startTls;
@@ -890,7 +1147,17 @@ export declare class TrustedCert extends Cert {
     static findInDatabase(subjectOrSubjectKeyId: DistinguishedName | string, db: RootCertsDatabase): Promise<Cert | undefined>;
 }
 
-export { types }
+export declare const types: {
+    setTypeParser(id: number, parseFn: (value: string) => any): void;
+    setTypeParser(
+    id: number,
+    format: 'text' | 'binary',
+    parseFn: (value: string) => any,
+    ): void;
+    getTypeParser(id: number, format?: 'text' | 'binary'): any;
+    arrayParser(source: string, transform: (entry: any) => any): any[];
+    builtins: { [key: string]: number };
+};
 
 export declare class UnsafeRawSql {
     sql: string;

--- a/index.js
+++ b/index.js
@@ -1,17 +1,17 @@
 "use strict";var So=Object.create;var Te=Object.defineProperty;var Eo=Object.getOwnPropertyDescriptor;var Ao=Object.getOwnPropertyNames;var Co=Object.getPrototypeOf,_o=Object.prototype.hasOwnProperty;var Io=(r,e,t)=>e in r?Te(r,e,{enumerable:!0,configurable:!0,writable:!0,value:t}):r[e]=t;var a=(r,e)=>Te(r,"name",{value:e,configurable:!0});var G=(r,e)=>()=>(r&&(e=r(r=0)),e);var T=(r,e)=>()=>(e||r((e={exports:{}}).exports,e),e.exports),te=(r,e)=>{for(var t in e)Te(r,t,{get:e[t],
 enumerable:!0})},On=(r,e,t,n)=>{if(e&&typeof e=="object"||typeof e=="function")for(let i of Ao(e))!_o.
 call(r,i)&&i!==t&&Te(r,i,{get:()=>e[i],enumerable:!(n=Eo(e,i))||n.enumerable});return r};var Ae=(r,e,t)=>(t=r!=null?So(Co(r)):{},On(e||!r||!r.__esModule?Te(t,"default",{value:r,enumerable:!0}):
-t,r)),O=r=>On(Te({},"__esModule",{value:!0}),r);var E=(r,e,t)=>Io(r,typeof e!="symbol"?e+"":e,t);var Nn=T(ft=>{"use strict";p();ft.byteLength=Po;ft.toByteArray=Ro;ft.fromByteArray=ko;var ue=[],re=[],
+t,r)),O=r=>On(Te({},"__esModule",{value:!0}),r);var E=(r,e,t)=>Io(r,typeof e!="symbol"?e+"":e,t);var Nn=T(ft=>{"use strict";p();ft.byteLength=Po;ft.toByteArray=Bo;ft.fromByteArray=ko;var ue=[],re=[],
 To=typeof Uint8Array<"u"?Uint8Array:Array,Qt="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz01\
 23456789+/";for(Ce=0,qn=Qt.length;Ce<qn;++Ce)ue[Ce]=Qt[Ce],re[Qt.charCodeAt(Ce)]=Ce;var Ce,qn;re[45]=
 62;re[95]=63;function Qn(r){var e=r.length;if(e%4>0)throw new Error("Invalid string. Length must be \
 a multiple of 4");var t=r.indexOf("=");t===-1&&(t=e);var n=t===e?0:4-t%4;return[t,n]}a(Qn,"getLens");
-function Po(r){var e=Qn(r),t=e[0],n=e[1];return(t+n)*3/4-n}a(Po,"byteLength");function Bo(r,e,t){return(e+
-t)*3/4-t}a(Bo,"_byteLength");function Ro(r){var e,t=Qn(r),n=t[0],i=t[1],s=new To(Bo(r,n,i)),o=0,u=i>
+function Po(r){var e=Qn(r),t=e[0],n=e[1];return(t+n)*3/4-n}a(Po,"byteLength");function Ro(r,e,t){return(e+
+t)*3/4-t}a(Ro,"_byteLength");function Bo(r){var e,t=Qn(r),n=t[0],i=t[1],s=new To(Ro(r,n,i)),o=0,u=i>
 0?n-4:n,c;for(c=0;c<u;c+=4)e=re[r.charCodeAt(c)]<<18|re[r.charCodeAt(c+1)]<<12|re[r.charCodeAt(c+2)]<<
 6|re[r.charCodeAt(c+3)],s[o++]=e>>16&255,s[o++]=e>>8&255,s[o++]=e&255;return i===2&&(e=re[r.charCodeAt(
 c)]<<2|re[r.charCodeAt(c+1)]>>4,s[o++]=e&255),i===1&&(e=re[r.charCodeAt(c)]<<10|re[r.charCodeAt(c+1)]<<
-4|re[r.charCodeAt(c+2)]>>2,s[o++]=e>>8&255,s[o++]=e&255),s}a(Ro,"toByteArray");function Lo(r){return ue[r>>
+4|re[r.charCodeAt(c+2)]>>2,s[o++]=e>>8&255,s[o++]=e&255),s}a(Bo,"toByteArray");function Lo(r){return ue[r>>
 18&63]+ue[r>>12&63]+ue[r>>6&63]+ue[r&63]}a(Lo,"tripletToBase64");function Fo(r,e,t){for(var n,i=[],s=e;s<
 t;s+=3)n=(r[s]<<16&16711680)+(r[s+1]<<8&65280)+(r[s+2]&255),i.push(Lo(n));return i.join("")}a(Fo,"en\
 codeChunk");function ko(r){for(var e,t=r.length,n=t%3,i=[],s=16383,o=0,u=t-n;o<u;o+=s)i.push(Fo(r,o,
@@ -24,7 +24,7 @@ f=(1<<l)-1,y=f>>1,g=i===23?Math.pow(2,-24)-Math.pow(2,-77):0,A=n?0:s-1,C=n?1:-1,
 1:0;for(e=Math.abs(e),isNaN(e)||e===1/0?(u=isNaN(e)?1:0,o=f):(o=Math.floor(Math.log(e)/Math.LN2),e*(c=
 Math.pow(2,-o))<1&&(o--,c*=2),o+y>=1?e+=g/c:e+=g*Math.pow(2,1-y),e*c>=2&&(o++,c/=2),o+y>=f?(u=0,o=f):
 o+y>=1?(u=(e*c-1)*Math.pow(2,i),o=o+y):(u=e*Math.pow(2,y-1)*Math.pow(2,i),o=0));i>=8;r[t+A]=u&255,A+=
-C,u/=256,i-=8);for(o=o<<i|u,l+=i;l>0;r[t+A]=o&255,A+=C,o/=256,l-=8);r[t+A-C]|=D*128}});var si=T(Le=>{"use strict";p();var Wt=Nn(),Be=Wn(),jn=typeof Symbol=="function"&&typeof Symbol.for==
+C,u/=256,i-=8);for(o=o<<i|u,l+=i;l>0;r[t+A]=o&255,A+=C,o/=256,l-=8);r[t+A-C]|=D*128}});var si=T(Le=>{"use strict";p();var Wt=Nn(),Re=Wn(),jn=typeof Symbol=="function"&&typeof Symbol.for==
 "function"?Symbol.for("nodejs.util.inspect.custom"):null;Le.Buffer=h;Le.SlowBuffer=Qo;Le.INSPECT_MAX_BYTES=
 50;var ht=2147483647;Le.kMaxLength=ht;h.TYPED_ARRAY_SUPPORT=Mo();!h.TYPED_ARRAY_SUPPORT&&typeof console<
 "u"&&typeof console.error=="function"&&console.error("This browser lacks typed array (Uint8Array) su\
@@ -165,10 +165,10 @@ a(function(e,t){return e=e>>>0,t||q(e,2,this.length),this[e]<<8|this[e+1]},"read
 readUint32LE=h.prototype.readUInt32LE=a(function(e,t){return e=e>>>0,t||q(e,4,this.length),(this[e]|
 this[e+1]<<8|this[e+2]<<16)+this[e+3]*16777216},"readUInt32LE");h.prototype.readUint32BE=h.prototype.
 readUInt32BE=a(function(e,t){return e=e>>>0,t||q(e,4,this.length),this[e]*16777216+(this[e+1]<<16|this[e+
-2]<<8|this[e+3])},"readUInt32BE");h.prototype.readBigUInt64LE=be(a(function(e){e=e>>>0,Re(e,"offset");
+2]<<8|this[e+3])},"readUInt32BE");h.prototype.readBigUInt64LE=be(a(function(e){e=e>>>0,Be(e,"offset");
 let t=this[e],n=this[e+7];(t===void 0||n===void 0)&&Ve(e,this.length-8);let i=t+this[++e]*2**8+this[++e]*
 2**16+this[++e]*2**24,s=this[++e]+this[++e]*2**8+this[++e]*2**16+n*2**24;return BigInt(i)+(BigInt(s)<<
-BigInt(32))},"readBigUInt64LE"));h.prototype.readBigUInt64BE=be(a(function(e){e=e>>>0,Re(e,"offset");
+BigInt(32))},"readBigUInt64LE"));h.prototype.readBigUInt64BE=be(a(function(e){e=e>>>0,Be(e,"offset");
 let t=this[e],n=this[e+7];(t===void 0||n===void 0)&&Ve(e,this.length-8);let i=t*2**24+this[++e]*2**16+
 this[++e]*2**8+this[++e],s=this[++e]*2**24+this[++e]*2**16+this[++e]*2**8+n;return(BigInt(i)<<BigInt(
 32))+BigInt(s)},"readBigUInt64BE"));h.prototype.readIntLE=a(function(e,t,n){e=e>>>0,t=t>>>0,n||q(e,t,
@@ -182,16 +182,16 @@ a(function(e,t){e=e>>>0,t||q(e,2,this.length);let n=this[e+1]|this[e]<<8;return 
 n},"readInt16BE");h.prototype.readInt32LE=a(function(e,t){return e=e>>>0,t||q(e,4,this.length),this[e]|
 this[e+1]<<8|this[e+2]<<16|this[e+3]<<24},"readInt32LE");h.prototype.readInt32BE=a(function(e,t){return e=
 e>>>0,t||q(e,4,this.length),this[e]<<24|this[e+1]<<16|this[e+2]<<8|this[e+3]},"readInt32BE");h.prototype.
-readBigInt64LE=be(a(function(e){e=e>>>0,Re(e,"offset");let t=this[e],n=this[e+7];(t===void 0||n===void 0)&&
+readBigInt64LE=be(a(function(e){e=e>>>0,Be(e,"offset");let t=this[e],n=this[e+7];(t===void 0||n===void 0)&&
 Ve(e,this.length-8);let i=this[e+4]+this[e+5]*2**8+this[e+6]*2**16+(n<<24);return(BigInt(i)<<BigInt(
 32))+BigInt(t+this[++e]*2**8+this[++e]*2**16+this[++e]*2**24)},"readBigInt64LE"));h.prototype.readBigInt64BE=
-be(a(function(e){e=e>>>0,Re(e,"offset");let t=this[e],n=this[e+7];(t===void 0||n===void 0)&&Ve(e,this.
+be(a(function(e){e=e>>>0,Be(e,"offset");let t=this[e],n=this[e+7];(t===void 0||n===void 0)&&Ve(e,this.
 length-8);let i=(t<<24)+this[++e]*2**16+this[++e]*2**8+this[++e];return(BigInt(i)<<BigInt(32))+BigInt(
 this[++e]*2**24+this[++e]*2**16+this[++e]*2**8+n)},"readBigInt64BE"));h.prototype.readFloatLE=a(function(e,t){
-return e=e>>>0,t||q(e,4,this.length),Be.read(this,e,!0,23,4)},"readFloatLE");h.prototype.readFloatBE=
-a(function(e,t){return e=e>>>0,t||q(e,4,this.length),Be.read(this,e,!1,23,4)},"readFloatBE");h.prototype.
-readDoubleLE=a(function(e,t){return e=e>>>0,t||q(e,8,this.length),Be.read(this,e,!0,52,8)},"readDoub\
-leLE");h.prototype.readDoubleBE=a(function(e,t){return e=e>>>0,t||q(e,8,this.length),Be.read(this,e,
+return e=e>>>0,t||q(e,4,this.length),Re.read(this,e,!0,23,4)},"readFloatLE");h.prototype.readFloatBE=
+a(function(e,t){return e=e>>>0,t||q(e,4,this.length),Re.read(this,e,!1,23,4)},"readFloatBE");h.prototype.
+readDoubleLE=a(function(e,t){return e=e>>>0,t||q(e,8,this.length),Re.read(this,e,!0,52,8)},"readDoub\
+leLE");h.prototype.readDoubleBE=a(function(e,t){return e=e>>>0,t||q(e,8,this.length),Re.read(this,e,
 !1,52,8)},"readDoubleBE");function V(r,e,t,n,i,s){if(!h.isBuffer(r))throw new TypeError('"buffer" ar\
 gument must be a Buffer instance');if(e>i||e<s)throw new RangeError('"value" argument is out of boun\
 ds');if(t+n>r.length)throw new RangeError("Index out of range")}a(V,"checkInt");h.prototype.writeUintLE=
@@ -233,10 +233,10 @@ t+4},"writeInt32BE");h.prototype.writeBigInt64LE=be(a(function(e,t=0){return Jn(
 a(function(e,t=0){return Xn(this,e,t,-BigInt("0x8000000000000000"),BigInt("0x7fffffffffffffff"))},"w\
 riteBigInt64BE"));function ei(r,e,t,n,i,s){if(t+n>r.length)throw new RangeError("Index out of range");
 if(t<0)throw new RangeError("Index out of range")}a(ei,"checkIEEE754");function ti(r,e,t,n,i){return e=
-+e,t=t>>>0,i||ei(r,e,t,4,34028234663852886e22,-34028234663852886e22),Be.write(r,e,t,n,23,4),t+4}a(ti,
++e,t=t>>>0,i||ei(r,e,t,4,34028234663852886e22,-34028234663852886e22),Re.write(r,e,t,n,23,4),t+4}a(ti,
 "writeFloat");h.prototype.writeFloatLE=a(function(e,t,n){return ti(this,e,t,!0,n)},"writeFloatLE");h.
 prototype.writeFloatBE=a(function(e,t,n){return ti(this,e,t,!1,n)},"writeFloatBE");function ri(r,e,t,n,i){
-return e=+e,t=t>>>0,i||ei(r,e,t,8,17976931348623157e292,-17976931348623157e292),Be.write(r,e,t,n,52,
+return e=+e,t=t>>>0,i||ei(r,e,t,8,17976931348623157e292,-17976931348623157e292),Re.write(r,e,t,n,52,
 8),t+8}a(ri,"writeDouble");h.prototype.writeDoubleLE=a(function(e,t,n){return ri(this,e,t,!0,n)},"wr\
 iteDoubleLE");h.prototype.writeDoubleBE=a(function(e,t,n){return ri(this,e,t,!1,n)},"writeDoubleBE");
 h.prototype.copy=a(function(e,t,n,i){if(!h.isBuffer(e))throw new TypeError("argument should be a Buf\
@@ -265,12 +265,12 @@ f range.`,i=t;return Number.isInteger(t)&&Math.abs(t)>2**32?i=Gn(String(t)):type
 t),(t>BigInt(2)**BigInt(32)||t<-(BigInt(2)**BigInt(32)))&&(i=Gn(i)),i+="n"),n+=` It must be ${e}. Re\
 ceived ${i}`,n},RangeError);function Gn(r){let e="",t=r.length,n=r[0]==="-"?1:0;for(;t>=n+4;t-=3)e=`\
 _${r.slice(t-3,t)}${e}`;return`${r.slice(0,t)}${e}`}a(Gn,"addNumericalSeparator");function Xo(r,e,t){
-Re(e,"offset"),(r[e]===void 0||r[e+t]===void 0)&&Ve(e,r.length-(t+1))}a(Xo,"checkBounds");function ni(r,e,t,n,i,s){
+Be(e,"offset"),(r[e]===void 0||r[e+t]===void 0)&&Ve(e,r.length-(t+1))}a(Xo,"checkBounds");function ni(r,e,t,n,i,s){
 if(r>t||r<e){let o=typeof e=="bigint"?"n":"",u;throw s>3?e===0||e===BigInt(0)?u=`>= 0${o} and < 2${o}\
  ** ${(s+1)*8}${o}`:u=`>= -(2${o} ** ${(s+1)*8-1}${o}) and < 2 ** ${(s+1)*8-1}${o}`:u=`>= ${e}${o} a\
-nd <= ${t}${o}`,new Pe.ERR_OUT_OF_RANGE("value",u,r)}Xo(n,i,s)}a(ni,"checkIntBI");function Re(r,e){if(typeof r!=
-"number")throw new Pe.ERR_INVALID_ARG_TYPE(e,"number",r)}a(Re,"validateNumber");function Ve(r,e,t){throw Math.
-floor(r)!==r?(Re(r,t),new Pe.ERR_OUT_OF_RANGE(t||"offset","an integer",r)):e<0?new Pe.ERR_BUFFER_OUT_OF_BOUNDS:
+nd <= ${t}${o}`,new Pe.ERR_OUT_OF_RANGE("value",u,r)}Xo(n,i,s)}a(ni,"checkIntBI");function Be(r,e){if(typeof r!=
+"number")throw new Pe.ERR_INVALID_ARG_TYPE(e,"number",r)}a(Be,"validateNumber");function Ve(r,e,t){throw Math.
+floor(r)!==r?(Be(r,t),new Pe.ERR_OUT_OF_RANGE(t||"offset","an integer",r)):e<0?new Pe.ERR_BUFFER_OUT_OF_BOUNDS:
 new Pe.ERR_OUT_OF_RANGE(t||"offset",`>= ${t?1:0} and <= ${e}`,r)}a(Ve,"boundsError");var ea=/[^+/0-9A-Za-z-_]/g;
 function ta(r){if(r=r.split("=")[0],r=r.trim().replace(ea,""),r.length<2)return"";for(;r.length%4!==
 0;)r=r+"=";return r}a(ta,"base64clean");function $t(r,e){e=e||1/0;let t,n=r.length,i=null,s=[];for(let o=0;o<
@@ -297,20 +297,20 @@ m.nextTick(()=>{})}catch{let e=Promise.resolve();m.nextTick=e.then.bind(e)}});va
 Fe&&typeof Fe.ownKeys=="function"?dt=Fe.ownKeys:Object.getOwnPropertySymbols?dt=a(function(e){return Object.
 getOwnPropertyNames(e).concat(Object.getOwnPropertySymbols(e))},"ReflectOwnKeys"):dt=a(function(e){return Object.
 getOwnPropertyNames(e)},"ReflectOwnKeys");function oa(r){console&&console.warn&&console.warn(r)}a(oa,
-"ProcessEmitWarning");var ui=Number.isNaN||a(function(e){return e!==e},"NumberIsNaN");function B(){B.
-init.call(this)}a(B,"EventEmitter");Yt.exports=B;Yt.exports.once=la;B.EventEmitter=B;B.prototype._events=
-void 0;B.prototype._eventsCount=0;B.prototype._maxListeners=void 0;var ai=10;function yt(r){if(typeof r!=
+"ProcessEmitWarning");var ui=Number.isNaN||a(function(e){return e!==e},"NumberIsNaN");function R(){R.
+init.call(this)}a(R,"EventEmitter");Yt.exports=R;Yt.exports.once=la;R.EventEmitter=R;R.prototype._events=
+void 0;R.prototype._eventsCount=0;R.prototype._maxListeners=void 0;var ai=10;function yt(r){if(typeof r!=
 "function")throw new TypeError('The "listener" argument must be of type Function. Received type '+typeof r)}
-a(yt,"checkListener");Object.defineProperty(B,"defaultMaxListeners",{enumerable:!0,get:a(function(){
+a(yt,"checkListener");Object.defineProperty(R,"defaultMaxListeners",{enumerable:!0,get:a(function(){
 return ai},"get"),set:a(function(r){if(typeof r!="number"||r<0||ui(r))throw new RangeError('The valu\
 e of "defaultMaxListeners" is out of range. It must be a non-negative number. Received '+r+".");ai=r},
-"set")});B.init=function(){(this._events===void 0||this._events===Object.getPrototypeOf(this)._events)&&
+"set")});R.init=function(){(this._events===void 0||this._events===Object.getPrototypeOf(this)._events)&&
 (this._events=Object.create(null),this._eventsCount=0),this._maxListeners=this._maxListeners||void 0};
-B.prototype.setMaxListeners=a(function(e){if(typeof e!="number"||e<0||ui(e))throw new RangeError('Th\
+R.prototype.setMaxListeners=a(function(e){if(typeof e!="number"||e<0||ui(e))throw new RangeError('Th\
 e value of "n" is out of range. It must be a non-negative number. Received '+e+".");return this._maxListeners=
-e,this},"setMaxListeners");function ci(r){return r._maxListeners===void 0?B.defaultMaxListeners:r._maxListeners}
-a(ci,"_getMaxListeners");B.prototype.getMaxListeners=a(function(){return ci(this)},"getMaxListeners");
-B.prototype.emit=a(function(e){for(var t=[],n=1;n<arguments.length;n++)t.push(arguments[n]);var i=e===
+e,this},"setMaxListeners");function ci(r){return r._maxListeners===void 0?R.defaultMaxListeners:r._maxListeners}
+a(ci,"_getMaxListeners");R.prototype.getMaxListeners=a(function(){return ci(this)},"getMaxListeners");
+R.prototype.emit=a(function(e){for(var t=[],n=1;n<arguments.length;n++)t.push(arguments[n]);var i=e===
 "error",s=this._events;if(s!==void 0)i=i&&s.error===void 0;else if(!i)return!1;if(i){var o;if(t.length>
 0&&(o=t[0]),o instanceof Error)throw o;var u=new Error("Unhandled error."+(o?" ("+o.message+")":""));
 throw u.context=o,u}var c=s[e];if(c===void 0)return!1;if(typeof c=="function")oi(c,this,t);else for(var l=c.
@@ -320,21 +320,21 @@ t),s=r._events,s===void 0?(s=r._events=Object.create(null),r._eventsCount=0):(s.
 "function"?o=s[e]=n?[t,o]:[o,t]:n?o.unshift(t):o.push(t),i=ci(r),i>0&&o.length>i&&!o.warned){o.warned=
 !0;var u=new Error("Possible EventEmitter memory leak detected. "+o.length+" "+String(e)+" listeners\
  added. Use emitter.setMaxListeners() to increase limit");u.name="MaxListenersExceededWarning",u.emitter=
-r,u.type=e,u.count=o.length,oa(u)}return r}a(li,"_addListener");B.prototype.addListener=a(function(e,t){
-return li(this,e,t,!1)},"addListener");B.prototype.on=B.prototype.addListener;B.prototype.prependListener=
+r,u.type=e,u.count=o.length,oa(u)}return r}a(li,"_addListener");R.prototype.addListener=a(function(e,t){
+return li(this,e,t,!1)},"addListener");R.prototype.on=R.prototype.addListener;R.prototype.prependListener=
 a(function(e,t){return li(this,e,t,!0)},"prependListener");function aa(){if(!this.fired)return this.
 target.removeListener(this.type,this.wrapFn),this.fired=!0,arguments.length===0?this.listener.call(this.
 target):this.listener.apply(this.target,arguments)}a(aa,"onceWrapper");function fi(r,e,t){var n={fired:!1,
 wrapFn:void 0,target:r,type:e,listener:t},i=aa.bind(n);return i.listener=t,n.wrapFn=i,i}a(fi,"_onceW\
-rap");B.prototype.once=a(function(e,t){return yt(t),this.on(e,fi(this,e,t)),this},"once");B.prototype.
+rap");R.prototype.once=a(function(e,t){return yt(t),this.on(e,fi(this,e,t)),this},"once");R.prototype.
 prependOnceListener=a(function(e,t){return yt(t),this.prependListener(e,fi(this,e,t)),this},"prepend\
-OnceListener");B.prototype.removeListener=a(function(e,t){var n,i,s,o,u;if(yt(t),i=this._events,i===
+OnceListener");R.prototype.removeListener=a(function(e,t){var n,i,s,o,u;if(yt(t),i=this._events,i===
 void 0)return this;if(n=i[e],n===void 0)return this;if(n===t||n.listener===t)--this._eventsCount===0?
 this._events=Object.create(null):(delete i[e],i.removeListener&&this.emit("removeListener",e,n.listener||
 t));else if(typeof n!="function"){for(s=-1,o=n.length-1;o>=0;o--)if(n[o]===t||n[o].listener===t){u=n[o].
 listener,s=o;break}if(s<0)return this;s===0?n.shift():ua(n,s),n.length===1&&(i[e]=n[0]),i.removeListener!==
-void 0&&this.emit("removeListener",e,u||t)}return this},"removeListener");B.prototype.off=B.prototype.
-removeListener;B.prototype.removeAllListeners=a(function(e){var t,n,i;if(n=this._events,n===void 0)return this;
+void 0&&this.emit("removeListener",e,u||t)}return this},"removeListener");R.prototype.off=R.prototype.
+removeListener;R.prototype.removeAllListeners=a(function(e){var t,n,i;if(n=this._events,n===void 0)return this;
 if(n.removeListener===void 0)return arguments.length===0?(this._events=Object.create(null),this._eventsCount=
 0):n[e]!==void 0&&(--this._eventsCount===0?this._events=Object.create(null):delete n[e]),this;if(arguments.
 length===0){var s=Object.keys(n),o;for(i=0;i<s.length;++i)o=s[i],o!=="removeListener"&&this.removeAllListeners(
@@ -342,11 +342,11 @@ o);return this.removeAllListeners("removeListener"),this._events=Object.create(n
 0,this}if(t=n[e],typeof t=="function")this.removeListener(e,t);else if(t!==void 0)for(i=t.length-1;i>=
 0;i--)this.removeListener(e,t[i]);return this},"removeAllListeners");function hi(r,e,t){var n=r._events;
 if(n===void 0)return[];var i=n[e];return i===void 0?[]:typeof i=="function"?t?[i.listener||i]:[i]:t?
-ca(i):di(i,i.length)}a(hi,"_listeners");B.prototype.listeners=a(function(e){return hi(this,e,!0)},"l\
-isteners");B.prototype.rawListeners=a(function(e){return hi(this,e,!1)},"rawListeners");B.listenerCount=
-function(r,e){return typeof r.listenerCount=="function"?r.listenerCount(e):pi.call(r,e)};B.prototype.
+ca(i):di(i,i.length)}a(hi,"_listeners");R.prototype.listeners=a(function(e){return hi(this,e,!0)},"l\
+isteners");R.prototype.rawListeners=a(function(e){return hi(this,e,!1)},"rawListeners");R.listenerCount=
+function(r,e){return typeof r.listenerCount=="function"?r.listenerCount(e):pi.call(r,e)};R.prototype.
 listenerCount=pi;function pi(r){var e=this._events;if(e!==void 0){var t=e[r];if(typeof t=="function")
-return 1;if(t!==void 0)return t.length}return 0}a(pi,"listenerCount");B.prototype.eventNames=a(function(){
+return 1;if(t!==void 0)return t.length}return 0}a(pi,"listenerCount");R.prototype.eventNames=a(function(){
 return this._eventsCount>0?dt(this._events):[]},"eventNames");function di(r,e){for(var t=new Array(e),
 n=0;n<e;++n)t[n]=r[n];return t}a(di,"arrayClone");function ua(r,e){for(;e+1<r.length;e++)r[e]=r[e+1];
 r.pop()}a(ua,"spliceOne");function ca(r){for(var e=new Array(r.length),t=0;t<e.length;++t)e[t]=r[t].
@@ -446,19 +446,19 @@ newEntry(),e))return this.entries}else t.value==='"'&&!t.escaped?(i&&this.newEnt
 not balanced");return this.entries}};a(vt,"ArrayParser");var tr=vt;function Ca(r){return r}a(Ca,"ide\
 ntity")});var nr=T((Xl,_i)=>{p();var _a=rr();_i.exports={create:a(function(r,e){return{parse:a(function(){return _a.
 parse(r,e)},"parse")}},"create")}});var Pi=T((rf,Ti)=>{"use strict";p();var Ia=/(\d{1,})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(\.\d{1,})?.*?( BC)?$/,
-Ta=/^(\d{1,})-(\d{2})-(\d{2})( BC)?$/,Pa=/([Z+-])(\d{2})?:?(\d{2})?:?(\d{2})?/,Ba=/^-?infinity$/;Ti.
-exports=a(function(e){if(Ba.test(e))return Number(e.replace("i","I"));var t=Ia.exec(e);if(!t)return Ra(
+Ta=/^(\d{1,})-(\d{2})-(\d{2})( BC)?$/,Pa=/([Z+-])(\d{2})?:?(\d{2})?:?(\d{2})?/,Ra=/^-?infinity$/;Ti.
+exports=a(function(e){if(Ra.test(e))return Number(e.replace("i","I"));var t=Ia.exec(e);if(!t)return Ba(
 e)||null;var n=!!t[8],i=parseInt(t[1],10);n&&(i=Ii(i));var s=parseInt(t[2],10)-1,o=t[3],u=parseInt(t[4],
 10),c=parseInt(t[5],10),l=parseInt(t[6],10),f=t[7];f=f?1e3*parseFloat(f):0;var y,g=La(e);return g!=null?
 (y=new Date(Date.UTC(i,s,o,u,c,l,f)),ir(i)&&y.setUTCFullYear(i),g!==0&&y.setTime(y.getTime()-g)):(y=
-new Date(i,s,o,u,c,l,f),ir(i)&&y.setFullYear(i)),y},"parseDate");function Ra(r){var e=Ta.exec(r);if(e){
+new Date(i,s,o,u,c,l,f),ir(i)&&y.setFullYear(i)),y},"parseDate");function Ba(r){var e=Ta.exec(r);if(e){
 var t=parseInt(e[1],10),n=!!e[4];n&&(t=Ii(t));var i=parseInt(e[2],10)-1,s=e[3],o=new Date(t,i,s);return ir(
-t)&&o.setFullYear(t),o}}a(Ra,"getDate");function La(r){if(r.endsWith("+00"))return 0;var e=Pa.exec(r.
+t)&&o.setFullYear(t),o}}a(Ba,"getDate");function La(r){if(r.endsWith("+00"))return 0;var e=Pa.exec(r.
 split(" ")[1]);if(e){var t=e[1];if(t==="Z")return 0;var n=t==="-"?-1:1,i=parseInt(e[2],10)*3600+parseInt(
 e[3]||0,10)*60+parseInt(e[4]||0,10);return i*n*1e3}}a(La,"timeZoneOffset");function Ii(r){return-(r-
-1)}a(Ii,"bcYearToNegativeYear");function ir(r){return r>=0&&r<100}a(ir,"is0To99")});var Ri=T((of,Bi)=>{p();Bi.exports=ka;var Fa=Object.prototype.hasOwnProperty;function ka(r){for(var e=1;e<
+1)}a(Ii,"bcYearToNegativeYear");function ir(r){return r>=0&&r<100}a(ir,"is0To99")});var Bi=T((of,Ri)=>{p();Ri.exports=ka;var Fa=Object.prototype.hasOwnProperty;function ka(r){for(var e=1;e<
 arguments.length;e++){var t=arguments[e];for(var n in t)Fa.call(t,n)&&(r[n]=t[n])}return r}a(ka,"ext\
-end")});var ki=T((cf,Fi)=>{"use strict";p();var Ma=Ri();Fi.exports=De;function De(r){if(!(this instanceof De))
+end")});var ki=T((cf,Fi)=>{"use strict";p();var Ma=Bi();Fi.exports=De;function De(r){if(!(this instanceof De))
 return new De(r);Ma(this,Va(r))}a(De,"PostgresInterval");var Ua=["seconds","minutes","hours","days",
 "months","years"];De.prototype.toPostgres=function(){var r=Ua.filter(this.hasOwnProperty,this);return this.
 milliseconds&&r.indexOf("seconds")<0&&r.push("seconds"),r.length===0?"0":r.map(function(e){var t=this[e]||
@@ -553,10 +553,10 @@ c=1541459225,l=0,f=0,y=[1116352408,1899447441,3049323471,3921009573,961987163,15
 1986661051,2177026350,2456956037,2730485921,2820302411,3259730800,3345764771,3516065817,3600352804,4094571909,
 275423344,430227734,506948616,659060556,883997877,958139571,1322822218,1537002063,1747873779,1955562222,
 2024104815,2227730452,2361852424,2428436474,2756734187,3204031479,3329325298],g=a((I,w)=>I>>>w|I<<32-
-w,"rrot"),A=new Uint32Array(64),C=new Uint8Array(64),D=a(()=>{for(let R=0,j=0;R<16;R++,j+=4)A[R]=C[j]<<
-24|C[j+1]<<16|C[j+2]<<8|C[j+3];for(let R=16;R<64;R++){let j=g(A[R-15],7)^g(A[R-15],18)^A[R-15]>>>3,fe=g(
-A[R-2],17)^g(A[R-2],19)^A[R-2]>>>10;A[R]=A[R-16]+j+A[R-7]+fe|0}let I=e,w=t,Z=n,W=i,J=s,X=o,oe=u,ae=c;
-for(let R=0;R<64;R++){let j=g(J,6)^g(J,11)^g(J,25),fe=J&X^~J&oe,me=ae+j+fe+y[R]+A[R]|0,Ge=g(I,2)^g(I,
+w,"rrot"),A=new Uint32Array(64),C=new Uint8Array(64),D=a(()=>{for(let B=0,j=0;B<16;B++,j+=4)A[B]=C[j]<<
+24|C[j+1]<<16|C[j+2]<<8|C[j+3];for(let B=16;B<64;B++){let j=g(A[B-15],7)^g(A[B-15],18)^A[B-15]>>>3,fe=g(
+A[B-2],17)^g(A[B-2],19)^A[B-2]>>>10;A[B]=A[B-16]+j+A[B-7]+fe|0}let I=e,w=t,Z=n,W=i,J=s,X=o,oe=u,ae=c;
+for(let B=0;B<64;B++){let j=g(J,6)^g(J,11)^g(J,25),fe=J&X^~J&oe,me=ae+j+fe+y[B]+A[B]|0,Ge=g(I,2)^g(I,
 13)^g(I,22),he=I&w^I&Z^w&Z,Ie=Ge+he|0;ae=oe,oe=X,X=J,J=W+me|0,W=Z,Z=w,w=I,I=me+Ie|0}e=e+I|0,t=t+w|0,
 n=n+Z|0,i=i+W|0,s=s+J|0,o=o+X|0,u=u+oe|0,c=c+ae|0,f=0},"process"),Y=a(I=>{typeof I=="string"&&(I=new TextEncoder().
 encode(I));for(let w=0;w<I.length;w++)C[f++]=I[w],f===64&&D();l+=I.length},"add"),P=a(()=>{if(C[f++]=
@@ -665,9 +665,9 @@ getUTCDate(),2)+"T"+N(r.getUTCHours(),2)+":"+N(r.getUTCMinutes(),2)+":"+N(r.getU
 r.getUTCMilliseconds(),3);return n+="+00:00",t&&(n+=" BC"),n}a(Tu,"dateToStringUTC");function Pu(r,e,t){
 return r=typeof r=="string"?{text:r}:r,e&&(typeof e=="function"?r.callback=e:r.values=e),t&&(r.callback=
 t),r}a(Pu,"normalizeQueryConfig");var dr=a(function(r){return Eu.createHash("md5").update(r,"utf-8").
-digest("hex")},"md5"),Bu=a(function(r,e,t){var n=dr(e+r),i=dr(d.concat([d.from(n),t]));return"md5"+i},
+digest("hex")},"md5"),Ru=a(function(r,e,t){var n=dr(e+r),i=dr(d.concat([d.from(n),t]));return"md5"+i},
 "postgresMd5PasswordHash");is.exports={prepareValue:a(function(e){return Ct(e)},"prepareValueWrapper"),
-normalizeQueryConfig:Pu,postgresMd5PasswordHash:Bu,md5:dr}});var ot={};te(ot,{default:()=>ku});var ku,at=G(()=>{"use strict";p();ku={}});var ds=T((nh,ps)=>{"use strict";p();var wr=(hr(),O(fr));function Mu(r){if(r.indexOf("SCRAM-SHA-256")===
+normalizeQueryConfig:Pu,postgresMd5PasswordHash:Ru,md5:dr}});var ot={};te(ot,{default:()=>ku});var ku,at=G(()=>{"use strict";p();ku={}});var ds=T((nh,ps)=>{"use strict";p();var wr=(hr(),O(fr));function Mu(r){if(r.indexOf("SCRAM-SHA-256")===
 -1)throw new Error("SASL: Only mechanism SCRAM-SHA-256 is currently supported");let e=wr.randomBytes(
 18).toString("base64");return{mechanism:"SCRAM-SHA-256",clientNonce:e,response:"n,,n=*,r="+e,message:"\
 SASLInitialResponse"}}a(Mu,"startSession");function Uu(r,e,t){if(r.message!=="SASLInitialResponse")throw new Error(
@@ -747,7 +747,7 @@ length===_r?o:null,o},uc=ye.exports.isValidEntry=function(r){for(var e={0:functi
 o)},2:function(o){return o.length>0},3:function(o){return o.length>0},4:function(o){return o.length>
 0}},t=0;t<Qe.length;t+=1){var n=e[t],i=r[Qe[t]]||"",s=n(i);if(!s)return!1}return!0}});var Cs=T((vh,Tr)=>{"use strict";p();var bh=(br(),O(gr)),As=(xr(),O(vr)),Pt=Es();Tr.exports=function(r,e){
 var t=Pt.getFileName();As.stat(t,function(n,i){if(n||!Pt.usePgPass(i,t))return e(void 0);var s=As.createReadStream(
-t);Pt.getPassword(r,s,e)})};Tr.exports.warnTo=Pt.warnTo});var _s={};te(_s,{default:()=>cc});var cc,Is=G(()=>{"use strict";p();cc={}});var Ps=T((Eh,Ts)=>{"use strict";p();var lc=(Jt(),O(bi)),Pr=(xr(),O(vr));function Br(r){if(r.charAt(0)===
+t);Pt.getPassword(r,s,e)})};Tr.exports.warnTo=Pt.warnTo});var _s={};te(_s,{default:()=>cc});var cc,Is=G(()=>{"use strict";p();cc={}});var Ps=T((Eh,Ts)=>{"use strict";p();var lc=(Jt(),O(bi)),Pr=(xr(),O(vr));function Rr(r){if(r.charAt(0)===
 "/"){var t=r.split(" ");return{host:t[0],database:t[1]}}var e=lc.parse(/ |%[^a-f0-9]|%[a-f0-9][^a-f0-9]/i.
 test(r)?encodeURI(r).replace(/\%25(\d\d)/g,"%$1"):r,!0),t=e.query;for(var n in t)Array.isArray(t[n])&&
 (t[n]=t[n][t[n].length-1]);var i=(e.auth||":").split(":");if(t.user=i[0],t.password=i.splice(1).join(
@@ -759,13 +759,13 @@ t.ssl==="0"&&(t.ssl=!1),(t.sslcert||t.sslkey||t.sslrootcert||t.sslmode)&&(t.ssl=
 cert=Pr.readFileSync(t.sslcert).toString()),t.sslkey&&(t.ssl.key=Pr.readFileSync(t.sslkey).toString()),
 t.sslrootcert&&(t.ssl.ca=Pr.readFileSync(t.sslrootcert).toString()),t.sslmode){case"disable":{t.ssl=
 !1;break}case"prefer":case"require":case"verify-ca":case"verify-full":break;case"no-verify":{t.ssl.rejectUnauthorized=
-!1;break}}return t}a(Br,"parse");Ts.exports=Br;Br.parse=Br});var Bt=T((_h,Ls)=>{"use strict";p();var fc=(Is(),O(_s)),Rs=it(),Bs=Ps().parse,H=a(function(r,e,t){return t===
-void 0?t=m.env["PG"+r.toUpperCase()]:t===!1||(t=m.env[t]),e[r]||t||Rs[r]},"val"),hc=a(function(){switch(m.
+!1;break}}return t}a(Rr,"parse");Ts.exports=Rr;Rr.parse=Rr});var Rt=T((_h,Ls)=>{"use strict";p();var fc=(Is(),O(_s)),Bs=it(),Rs=Ps().parse,H=a(function(r,e,t){return t===
+void 0?t=m.env["PG"+r.toUpperCase()]:t===!1||(t=m.env[t]),e[r]||t||Bs[r]},"val"),hc=a(function(){switch(m.
 env.PGSSLMODE){case"disable":return!1;case"prefer":case"require":case"verify-ca":case"verify-full":return!0;case"\
-no-verify":return{rejectUnauthorized:!1}}return Rs.ssl},"readSSLConfigFromEnvironment"),Ne=a(function(r){
+no-verify":return{rejectUnauthorized:!1}}return Bs.ssl},"readSSLConfigFromEnvironment"),Ne=a(function(r){
 return"'"+(""+r).replace(/\\/g,"\\\\").replace(/'/g,"\\'")+"'"},"quoteParamValue"),ie=a(function(r,e,t){
-var n=e[t];n!=null&&r.push(t+"="+Ne(n))},"add"),Lr=class Lr{constructor(e){e=typeof e=="string"?Bs(e):
-e||{},e.connectionString&&(e=Object.assign({},e,Bs(e.connectionString))),this.user=H("user",e),this.
+var n=e[t];n!=null&&r.push(t+"="+Ne(n))},"add"),Lr=class Lr{constructor(e){e=typeof e=="string"?Rs(e):
+e||{},e.connectionString&&(e=Object.assign({},e,Rs(e.connectionString))),this.user=H("user",e),this.
 database=H("database",e),this.database===void 0&&(this.database=this.user),this.port=parseInt(H("por\
 t",e),10),this.host=H("host",e),Object.defineProperty(this,"password",{configurable:!0,enumerable:!1,
 writable:!0,value:H("password",e)}),this.binary=H("binary",e),this.options=H("options",e),this.ssl=typeof e.
@@ -786,7 +786,7 @@ slkey"),ie(t,n,"sslcert"),ie(t,n,"sslrootcert"),this.database&&t.push("dbname="+
 replication&&t.push("replication="+Ne(this.replication)),this.host&&t.push("host="+Ne(this.host)),this.
 isDomainSocket)return e(null,t.join(" "));this.client_encoding&&t.push("client_encoding="+Ne(this.client_encoding)),
 fc.lookup(this.host,function(i,s){return i?e(i,null):(t.push("hostaddr="+Ne(s)),e(null,t.join(" ")))})}};
-a(Lr,"ConnectionParameters");var Rr=Lr;Ls.exports=Rr});var Ms=T((Ph,ks)=>{"use strict";p();var pc=tt(),Fs=/^([A-Za-z]+)(?: (\d+))?(?: (\d+))?/,kr=class kr{constructor(e,t){
+a(Lr,"ConnectionParameters");var Br=Lr;Ls.exports=Br});var Ms=T((Ph,ks)=>{"use strict";p();var pc=tt(),Fs=/^([A-Za-z]+)(?: (\d+))?(?: (\d+))?/,kr=class kr{constructor(e,t){
 this.command=null,this.rowCount=null,this.oid=null,this.rows=[],this.fields=[],this._parsers=void 0,
 this._types=t,this.RowCtor=null,this.rowAsArray=e==="array",this.rowAsArray&&(this.parseRow=this._parseRowAsArray)}addCommandComplete(e){
 var t;e.text?t=Fs.exec(e.text):t=Fs.exec(e.command),t&&(this.command=t[1],t[3]?(this.oid=parseInt(t[2],
@@ -854,7 +854,7 @@ var cn=class cn{constructor(e,t){this.length=e,this.text=t,this.name="commandCom
 ndCompleteMessage");var zr=cn;_.CommandCompleteMessage=zr;var ln=class ln{constructor(e,t){this.length=
 e,this.fields=t,this.name="dataRow",this.fieldCount=t.length}};a(ln,"DataRowMessage");var Kr=ln;_.DataRowMessage=
 Kr;var fn=class fn{constructor(e,t){this.length=e,this.message=t,this.name="notice"}};a(fn,"NoticeMe\
-ssage");var Yr=fn;_.NoticeMessage=Yr});var Qs=T(Rt=>{"use strict";p();Object.defineProperty(Rt,"__esModule",{value:!0});Rt.Writer=void 0;var dn=class dn{constructor(e=256){
+ssage");var Yr=fn;_.NoticeMessage=Yr});var Qs=T(Bt=>{"use strict";p();Object.defineProperty(Bt,"__esModule",{value:!0});Bt.Writer=void 0;var dn=class dn{constructor(e=256){
 this.size=e,this.offset=5,this.headerPosition=0,this.buffer=d.allocUnsafe(e)}ensure(e){if(this.buffer.
 length-this.offset<e){let n=this.buffer,i=n.length+(n.length>>1)+e;this.buffer=d.allocUnsafe(i),n.copy(
 this.buffer)}}addInt32(e){return this.ensure(4),this.buffer[this.offset++]=e>>>24&255,this.buffer[this.
@@ -866,7 +866,7 @@ return this.ensure(t),this.buffer.write(e,this.offset),this.offset+=t,this}add(e
 e.length),e.copy(this.buffer,this.offset),this.offset+=e.length,this}join(e){if(e){this.buffer[this.
 headerPosition]=e;let t=this.offset-(this.headerPosition+1);this.buffer.writeInt32BE(t,this.headerPosition+
 1)}return this.buffer.slice(e?0:5,this.offset)}flush(e){let t=this.join(e);return this.offset=5,this.
-headerPosition=0,this.buffer=d.allocUnsafe(this.size),t}};a(dn,"Writer");var pn=dn;Rt.Writer=pn});var Ws=T(Ft=>{"use strict";p();Object.defineProperty(Ft,"__esModule",{value:!0});Ft.serialize=void 0;
+headerPosition=0,this.buffer=d.allocUnsafe(this.size),t}};a(dn,"Writer");var pn=dn;Bt.Writer=pn});var Ws=T(Ft=>{"use strict";p();Object.defineProperty(Ft,"__esModule",{value:!0});Ft.serialize=void 0;
 var yn=Qs(),F=new yn.Writer,yc=a(r=>{F.addInt16(3).addInt16(0);for(let n of Object.keys(r))F.addCString(
 n).addCString(r[n]);F.addCString("client_encoding").addCString("UTF8");let e=F.addCString("").flush(),
 t=e.length+4;return new yn.Writer().addInt32(t).add(e).flush()},"startup"),mc=a(()=>{let r=d.allocUnsafe(
@@ -889,11 +889,11 @@ F.addInt16(n?1:0),F.flush(66)},"bind"),Ac=d.from([69,0,0,0,9,0,0,0,0,0]),Cc=a(r=
 6),t.writeInt32BE(r,8),t.writeInt32BE(e,12),t},"cancel"),mn=a((r,e)=>{let n=4+d.byteLength(e)+1,i=d.
 allocUnsafe(1+n);return i[0]=r,i.writeInt32BE(n,1),i.write(e,5,"utf-8"),i[n]=0,i},"cstringMessage"),
 Ic=F.addCString("P").flush(68),Tc=F.addCString("S").flush(68),Pc=a(r=>r.name?mn(68,`${r.type}${r.name||
-""}`):r.type==="P"?Ic:Tc,"describe"),Bc=a(r=>{let e=`${r.type}${r.name||""}`;return mn(67,e)},"close"),
-Rc=a(r=>F.add(r).flush(100),"copyData"),Lc=a(r=>mn(102,r),"copyFail"),Lt=a(r=>d.from([r,0,0,0,4]),"c\
+""}`):r.type==="P"?Ic:Tc,"describe"),Rc=a(r=>{let e=`${r.type}${r.name||""}`;return mn(67,e)},"close"),
+Bc=a(r=>F.add(r).flush(100),"copyData"),Lc=a(r=>mn(102,r),"copyFail"),Lt=a(r=>d.from([r,0,0,0,4]),"c\
 odeOnlyBuffer"),Fc=Lt(72),kc=Lt(83),Mc=Lt(88),Uc=Lt(99),Dc={startup:yc,password:wc,requestSsl:mc,sendSASLInitialResponseMessage:gc,
-sendSCRAMClientFinalMessage:bc,query:vc,parse:xc,bind:Ec,execute:Cc,describe:Pc,close:Bc,flush:a(()=>Fc,
-"flush"),sync:a(()=>kc,"sync"),end:a(()=>Mc,"end"),copyData:Rc,copyDone:a(()=>Uc,"copyDone"),copyFail:Lc,
+sendSCRAMClientFinalMessage:bc,query:vc,parse:xc,bind:Ec,execute:Cc,describe:Pc,close:Rc,flush:a(()=>Fc,
+"flush"),sync:a(()=>kc,"sync"),end:a(()=>Mc,"end"),copyData:Bc,copyDone:a(()=>Uc,"copyDone"),copyFail:Lc,
 cancel:_c};Ft.serialize=Dc});var js=T(kt=>{"use strict";p();Object.defineProperty(kt,"__esModule",{value:!0});kt.BufferReader=void 0;
 var Oc=d.allocUnsafe(0),gn=class gn{constructor(e=0){this.offset=e,this.buffer=Oc,this.encoding="utf\
 -8"}setBuffer(e,t){this.offset=e,this.buffer=t}int16(){let e=this.buffer.readInt16BE(this.offset);return this.
@@ -986,7 +986,7 @@ this.stream.end();return}return this.stream.write(Kc,()=>{this.stream.end()})}cl
 close(e))}describe(e){this._send(Q.describe(e))}sendCopyFromChunk(e){this._send(Q.copyData(e))}endCopyFrom(){
 this._send(Q.copyDone())}sendCopyFail(e){this._send(Q.copyFail(e))}};a(An,"Connection");var En=An;Zs.
 exports=En});var eo=T((sp,Xs)=>{"use strict";p();var Yc=ve().EventEmitter,ip=(at(),O(ot)),Zc=st(),_n=ds(),Jc=Cs(),
-Xc=At(),el=Bt(),Js=qs(),tl=it(),rl=Cn(),In=class In extends Yc{constructor(e){super(),this.connectionParameters=
+Xc=At(),el=Rt(),Js=qs(),tl=it(),rl=Cn(),In=class In extends Yc{constructor(e){super(),this.connectionParameters=
 new el(e),this.user=this.connectionParameters.user,this.database=this.connectionParameters.database,
 this.port=this.connectionParameters.port,this.host=this.connectionParameters.host,Object.defineProperty(
 this,"password",{configurable:!0,enumerable:!1,writable:!0,value:this.connectionParameters.password}),
@@ -1078,9 +1078,9 @@ s)}ref(){this.connection.ref()}unref(){this.connection.unref()}end(e){if(this._e
 _connecting)if(e)e();else return this._Promise.resolve();if(this.activeQuery||!this._queryable?this.
 connection.stream.destroy():this.connection.end(),e)this.connection.once("end",e);else return new this.
 _Promise(t=>{this.connection.once("end",t)})}};a(In,"Client");var Ut=In;Ut.Query=Js;Xs.exports=Ut});var io=T((up,no)=>{"use strict";p();var nl=ve().EventEmitter,to=a(function(){},"NOOP"),ro=a((r,e)=>{
-let t=r.findIndex(e);return t===-1?void 0:r.splice(t,1)[0]},"removeWhere"),Bn=class Bn{constructor(e,t,n){
-this.client=e,this.idleListener=t,this.timeoutId=n}};a(Bn,"IdleItem");var Tn=Bn,Rn=class Rn{constructor(e){
-this.callback=e}};a(Rn,"PendingItem");var je=Rn;function il(){throw new Error("Release called on cli\
+let t=r.findIndex(e);return t===-1?void 0:r.splice(t,1)[0]},"removeWhere"),Rn=class Rn{constructor(e,t,n){
+this.client=e,this.idleListener=t,this.timeoutId=n}};a(Rn,"IdleItem");var Tn=Rn,Bn=class Bn{constructor(e){
+this.callback=e}};a(Bn,"PendingItem");var je=Bn;function il(){throw new Error("Release called on cli\
 ent which has already been released to the pool.")}a(il,"throwOnDoubleRelease");function Dt(r,e){if(e)
 return{callback:e,result:void 0};let t,n,i=a(function(o,u){o?t(o):n(u)},"cb"),s=new r(function(o,u){
 n=o,t=u}).catch(o=>{throw Error.captureStackTrace(o),o});return{callback:i,result:s}}a(Dt,"promisify");
@@ -1176,7 +1176,7 @@ native.execute(this.name,n,t)}return r.native.prepare(this.name,this.text,n.leng
 t(s):(r.namedQueries[e.name]=e.text,e.native.execute(e.name,n,t))})}else if(this.values){if(!Array.isArray(
 this.values)){let s=new Error("Query values must be an array");return t(s)}var i=this.values.map(Fn.
 prepareValue);r.native.query(this.text,i,t)}else r.native.query(this.text,t)}});var yo=T((wp,po)=>{"use strict";p();var ll=(oo(),O(so)),fl=At(),mp=ao(),fo=ve().EventEmitter,hl=(at(),O(ot)),
-pl=Bt(),ho=lo(),K=po.exports=function(r){fo.call(this),r=r||{},this._Promise=r.Promise||b.Promise,this.
+pl=Rt(),ho=lo(),K=po.exports=function(r){fo.call(this),r=r||{},this._Promise=r.Promise||b.Promise,this.
 _types=new fl(r.types),this.native=new ll({types:this._types}),this._queryQueue=[],this._ending=!1,this.
 _connecting=!1,this._connected=!1,this._queryable=!0;var e=this.connectionParameters=new pl(r);this.
 user=e.user,Object.defineProperty(this,"password",{configurable:!0,enumerable:!1,writable:!0,value:e.
@@ -1264,7 +1264,7 @@ E(this,"code");E(this,"detail");E(this,"hint");E(this,"position");E(this,"intern
 E(this,"constraint");E(this,"file");E(this,"line");E(this,"routine");E(this,"sourceError");"captureS\
 tackTrace"in Error&&typeof Error.captureStackTrace=="function"&&Error.captureStackTrace(this,_t)}};a(
 _t,"NeonDbError");var de=_t,ss="transaction() expects an array of queries, or a function returning a\
-n array of queries",Ru=["severity","code","detail","hint","position","internalPosition","internalQue\
+n array of queries",Bu=["severity","code","detail","hint","position","internalPosition","internalQue\
 ry","where","schema","table","column","dataType","constraint","file","line","routine"];function Lu(r){
 return r instanceof d?"\\x"+Ai(r):r}a(Lu,"encodeBuffersAsBytea");function os(r){let{query:e,params:t}=r instanceof
 Me?r.toParameterizedQuery():r;return{query:e,params:t.map(n=>Lu((0,cs.prepareValue)(n)))}}a(os,"prep\
@@ -1282,14 +1282,14 @@ Y,new Me(P,I))}a(D,"templateFn"),D.query=(P,I,w)=>new xe(Y,{query:P,params:I??[]
 P),D.transaction=async(P,I)=>{if(typeof P=="function"&&(P=P(D)),!Array.isArray(P))throw new Error(ss);
 P.forEach(W=>{if(!(W instanceof xe))throw new Error(ss)});let w=P.map(W=>W.queryData),Z=P.map(W=>W.opts??
 {});return Y(w,Z,I)};async function Y(P,I,w){let{fetchEndpoint:Z,fetchFunction:W}=se,J=Array.isArray(
-P)?{queries:P.map(ee=>os(ee))}:os(P),X=n??{},oe=e??!1,ae=t??!1,R=i,j=s,fe=o;w!==void 0&&(w.fetchOptions!==
+P)?{queries:P.map(ee=>os(ee))}:os(P),X=n??{},oe=e??!1,ae=t??!1,B=i,j=s,fe=o;w!==void 0&&(w.fetchOptions!==
 void 0&&(X={...X,...w.fetchOptions}),w.arrayMode!==void 0&&(oe=w.arrayMode),w.fullResults!==void 0&&
-(ae=w.fullResults),w.isolationLevel!==void 0&&(R=w.isolationLevel),w.readOnly!==void 0&&(j=w.readOnly),
+(ae=w.fullResults),w.isolationLevel!==void 0&&(B=w.isolationLevel),w.readOnly!==void 0&&(j=w.readOnly),
 w.deferrable!==void 0&&(fe=w.deferrable)),I!==void 0&&!Array.isArray(I)&&I.fetchOptions!==void 0&&(X=
 {...X,...I.fetchOptions});let me=u;!Array.isArray(I)&&I?.authToken!==void 0&&(me=I.authToken);let Ge=typeof Z==
 "function"?Z(g,A,{jwtAuth:me!==void 0}):Z,he={"Neon-Connection-String":r,"Neon-Raw-Text-Output":"tru\
 e","Neon-Array-Mode":"true"},Ie=await Fu(me);Ie&&(he.Authorization=`Bearer ${Ie}`),Array.isArray(P)&&
-(R!==void 0&&(he["Neon-Batch-Isolation-Level"]=R),j!==void 0&&(he["Neon-Batch-Read-Only"]=String(j)),
+(B!==void 0&&(he["Neon-Batch-Isolation-Level"]=B),j!==void 0&&(he["Neon-Batch-Read-Only"]=String(j)),
 fe!==void 0&&(he["Neon-Batch-Deferrable"]=String(fe))),c||se.disableWarningInBrowsers||Ke();let we;try{
 we=await(W??fetch)(Ge,{method:"POST",body:JSON.stringify(J),headers:he,...X})}catch(ee){let M=new de(
 `Error connecting to database: ${ee}`);throw M.sourceError=ee,M}if(we.ok){let ee=await we.json();if(Array.
@@ -1297,7 +1297,7 @@ isArray(P)){let M=ee.results;if(!Array.isArray(M))throw new de("Neon internal er
 lt format");return M.map(($,ge)=>{let qt=I[ge]??{},vo=qt.arrayMode??oe,xo=qt.fullResults??ae;return as(
 $,{arrayMode:vo,fullResults:xo,types:qt.types})})}else{let M=I??{},$=M.arrayMode??oe,ge=M.fullResults??
 ae;return as(ee,{arrayMode:$,fullResults:ge,types:M.types})}}else{let{status:ee}=we;if(ee===400){let M=await we.
-json(),$=new de(M.message);for(let ge of Ru)$[ge]=M[ge]??void 0;throw $}else{let M=await we.text();throw new de(
+json(),$=new de(M.message);for(let ge of Bu)$[ge]=M[ge]??void 0;throw $}else{let M=await we.text();throw new de(
 `Server error (HTTP status ${ee}): ${M}`)}}}return a(Y,"execute"),D}a(yr,"neon");var mr=class mr{constructor(e,t,n){
 this.execute=e;this.queryData=t;this.opts=n}then(e,t){return this.execute(this.queryData,this.opts).
 then(e,t)}catch(e){return this.execute(this.queryData,this.opts).catch(e)}finally(e){return this.execute(
@@ -1340,14 +1340,14 @@ length===i.clientNonce.length)throw new Error("SASL: SCRAM-SERVER-FIRST-MESSAGE:
 [g,d.from([0,0,0,1])]))),P=Y;for(var I=0;I<y-1;I++)Y=new Uint8Array(await n.sign("HMAC",D,Y)),P=d.from(
 P.map((M,$)=>P[$]^Y[$]));let w=P,Z=await n.importKey("raw",w,{name:"HMAC",hash:{name:"SHA-256"}},!1,
 ["sign"]),W=new Uint8Array(await n.sign("HMAC",Z,A.encode("Client Key"))),J=await n.digest("SHA-256",
-W),X="n=*,r="+i.clientNonce,oe="r="+c+",s="+l+",i="+y,ae="c=biws,r="+c,R=X+","+oe+","+ae,j=await n.importKey(
+W),X="n=*,r="+i.clientNonce,oe="r="+c+",s="+l+",i="+y,ae="c=biws,r="+c,B=X+","+oe+","+ae,j=await n.importKey(
 "raw",J,{name:"HMAC",hash:{name:"SHA-256"}},!1,["sign"]);var fe=new Uint8Array(await n.sign("HMAC",j,
-A.encode(R))),me=d.from(W.map((M,$)=>W[$]^fe[$])),Ge=me.toString("base64");let he=await n.importKey(
+A.encode(B))),me=d.from(W.map((M,$)=>W[$]^fe[$])),Ge=me.toString("base64");let he=await n.importKey(
 "raw",w,{name:"HMAC",hash:{name:"SHA-256"}},!1,["sign"]),Ie=await n.sign("HMAC",he,A.encode("Server \
 Key")),we=await n.importKey("raw",Ie,{name:"HMAC",hash:{name:"SHA-256"}},!1,["sign"]);var ee=d.from(
-await n.sign("HMAC",we,A.encode(R)));i.message="SASLResponse",i.serverSignature=ee.toString("base64"),
+await n.sign("HMAC",we,A.encode(B)));i.message="SASLResponse",i.serverSignature=ee.toString("base64"),
 i.response=ae+",p="+Ge,this.connection.sendSCRAMClientFinalMessage(this.saslSession.response)}};a(Un,
-"NeonClient");var $e=Un;ke();var bo=Ae(Bt());function vl(r,e){if(e)return{callback:e,result:void 0};let t,n,i=a(function(o,u){o?t(o):n(u)},"cb"),
+"NeonClient");var $e=Un;ke();var bo=Ae(Rt());function vl(r,e){if(e)return{callback:e,result:void 0};let t,n,i=a(function(o,u){o?t(o):n(u)},"cb"),
 s=new r(function(o,u){n=o,t=u});return{callback:i,result:s}}a(vl,"promisify");var Dn=class Dn extends go.Pool{constructor(){
 super(...arguments);E(this,"Client",$e);E(this,"hasFetchUnsupportedListeners",!1);E(this,"addListene\
 r",this.on)}on(t,n){return t!=="error"&&(this.hasFetchUnsupportedListeners=!0),super.on(t,n)}query(t,n,i){

--- a/index.mjs
+++ b/index.mjs
@@ -2,17 +2,17 @@
 var So=Object.create;var Ie=Object.defineProperty;var Eo=Object.getOwnPropertyDescriptor;var Ao=Object.getOwnPropertyNames;var Co=Object.getPrototypeOf,_o=Object.prototype.hasOwnProperty;var Io=(r,e,t)=>e in r?Ie(r,e,{enumerable:!0,configurable:!0,writable:!0,value:t}):r[e]=t;var a=(r,e)=>Ie(r,"name",{value:e,configurable:!0});var G=(r,e)=>()=>(r&&(e=r(r=0)),e);var T=(r,e)=>()=>(e||r((e={exports:{}}).exports,e),e.exports),ie=(r,e)=>{for(var t in e)Ie(r,t,{get:e[t],
 enumerable:!0})},Dn=(r,e,t,n)=>{if(e&&typeof e=="object"||typeof e=="function")for(let i of Ao(e))!_o.
 call(r,i)&&i!==t&&Ie(r,i,{get:()=>e[i],enumerable:!(n=Eo(e,i))||n.enumerable});return r};var Se=(r,e,t)=>(t=r!=null?So(Co(r)):{},Dn(e||!r||!r.__esModule?Ie(t,"default",{value:r,enumerable:!0}):
-t,r)),O=r=>Dn(Ie({},"__esModule",{value:!0}),r);var E=(r,e,t)=>Io(r,typeof e!="symbol"?e+"":e,t);var Qn=T(lt=>{"use strict";p();lt.byteLength=Po;lt.toByteArray=Ro;lt.fromByteArray=ko;var ae=[],te=[],
+t,r)),O=r=>Dn(Ie({},"__esModule",{value:!0}),r);var E=(r,e,t)=>Io(r,typeof e!="symbol"?e+"":e,t);var Qn=T(lt=>{"use strict";p();lt.byteLength=Po;lt.toByteArray=Bo;lt.fromByteArray=ko;var ae=[],te=[],
 To=typeof Uint8Array<"u"?Uint8Array:Array,qt="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz01\
 23456789+/";for(Ee=0,On=qt.length;Ee<On;++Ee)ae[Ee]=qt[Ee],te[qt.charCodeAt(Ee)]=Ee;var Ee,On;te[45]=
 62;te[95]=63;function qn(r){var e=r.length;if(e%4>0)throw new Error("Invalid string. Length must be \
 a multiple of 4");var t=r.indexOf("=");t===-1&&(t=e);var n=t===e?0:4-t%4;return[t,n]}a(qn,"getLens");
-function Po(r){var e=qn(r),t=e[0],n=e[1];return(t+n)*3/4-n}a(Po,"byteLength");function Bo(r,e,t){return(e+
-t)*3/4-t}a(Bo,"_byteLength");function Ro(r){var e,t=qn(r),n=t[0],i=t[1],s=new To(Bo(r,n,i)),o=0,u=i>
+function Po(r){var e=qn(r),t=e[0],n=e[1];return(t+n)*3/4-n}a(Po,"byteLength");function Ro(r,e,t){return(e+
+t)*3/4-t}a(Ro,"_byteLength");function Bo(r){var e,t=qn(r),n=t[0],i=t[1],s=new To(Ro(r,n,i)),o=0,u=i>
 0?n-4:n,c;for(c=0;c<u;c+=4)e=te[r.charCodeAt(c)]<<18|te[r.charCodeAt(c+1)]<<12|te[r.charCodeAt(c+2)]<<
 6|te[r.charCodeAt(c+3)],s[o++]=e>>16&255,s[o++]=e>>8&255,s[o++]=e&255;return i===2&&(e=te[r.charCodeAt(
 c)]<<2|te[r.charCodeAt(c+1)]>>4,s[o++]=e&255),i===1&&(e=te[r.charCodeAt(c)]<<10|te[r.charCodeAt(c+1)]<<
-4|te[r.charCodeAt(c+2)]>>2,s[o++]=e>>8&255,s[o++]=e&255),s}a(Ro,"toByteArray");function Lo(r){return ae[r>>
+4|te[r.charCodeAt(c+2)]>>2,s[o++]=e>>8&255,s[o++]=e&255),s}a(Bo,"toByteArray");function Lo(r){return ae[r>>
 18&63]+ae[r>>12&63]+ae[r>>6&63]+ae[r&63]}a(Lo,"tripletToBase64");function Fo(r,e,t){for(var n,i=[],s=e;s<
 t;s+=3)n=(r[s]<<16&16711680)+(r[s+1]<<8&65280)+(r[s+2]&255),i.push(Lo(n));return i.join("")}a(Fo,"en\
 codeChunk");function ko(r){for(var e,t=r.length,n=t%3,i=[],s=16383,o=0,u=t-n;o<u;o+=s)i.push(Fo(r,o,
@@ -25,9 +25,9 @@ f=(1<<l)-1,y=f>>1,g=i===23?Math.pow(2,-24)-Math.pow(2,-77):0,A=n?0:s-1,C=n?1:-1,
 1:0;for(e=Math.abs(e),isNaN(e)||e===1/0?(u=isNaN(e)?1:0,o=f):(o=Math.floor(Math.log(e)/Math.LN2),e*(c=
 Math.pow(2,-o))<1&&(o--,c*=2),o+y>=1?e+=g/c:e+=g*Math.pow(2,1-y),e*c>=2&&(o++,c/=2),o+y>=f?(u=0,o=f):
 o+y>=1?(u=(e*c-1)*Math.pow(2,i),o=o+y):(u=e*Math.pow(2,y-1)*Math.pow(2,i),o=0));i>=8;r[t+A]=u&255,A+=
-C,u/=256,i-=8);for(o=o<<i|u,l+=i;l>0;r[t+A]=o&255,A+=C,o/=256,l-=8);r[t+A-C]|=D*128}});var ii=T(Re=>{"use strict";p();var Nt=Qn(),Pe=Nn(),Wn=typeof Symbol=="function"&&typeof Symbol.for==
-"function"?Symbol.for("nodejs.util.inspect.custom"):null;Re.Buffer=h;Re.SlowBuffer=Qo;Re.INSPECT_MAX_BYTES=
-50;var ft=2147483647;Re.kMaxLength=ft;h.TYPED_ARRAY_SUPPORT=Mo();!h.TYPED_ARRAY_SUPPORT&&typeof console<
+C,u/=256,i-=8);for(o=o<<i|u,l+=i;l>0;r[t+A]=o&255,A+=C,o/=256,l-=8);r[t+A-C]|=D*128}});var ii=T(Be=>{"use strict";p();var Nt=Qn(),Pe=Nn(),Wn=typeof Symbol=="function"&&typeof Symbol.for==
+"function"?Symbol.for("nodejs.util.inspect.custom"):null;Be.Buffer=h;Be.SlowBuffer=Qo;Be.INSPECT_MAX_BYTES=
+50;var ft=2147483647;Be.kMaxLength=ft;h.TYPED_ARRAY_SUPPORT=Mo();!h.TYPED_ARRAY_SUPPORT&&typeof console<
 "u"&&typeof console.error=="function"&&console.error("This browser lacks typed array (Uint8Array) su\
 pport which is required by `buffer` v5.x. Use `buffer` v4.x if you require old browser support.");function Mo(){
 try{let r=new Uint8Array(1),e={foo:a(function(){return 42},"foo")};return Object.setPrototypeOf(e,Uint8Array.
@@ -100,7 +100,7 @@ a(function(){let e=this.length;if(e%8!==0)throw new RangeError("Buffer size must
 "swap64");h.prototype.toString=a(function(){let e=this.length;return e===0?"":arguments.length===0?Yn(
 this,0,e):No.apply(this,arguments)},"toString");h.prototype.toLocaleString=h.prototype.toString;h.prototype.
 equals=a(function(e){if(!h.isBuffer(e))throw new TypeError("Argument must be a Buffer");return this===
-e?!0:h.compare(this,e)===0},"equals");h.prototype.inspect=a(function(){let e="",t=Re.INSPECT_MAX_BYTES;
+e?!0:h.compare(this,e)===0},"equals");h.prototype.inspect=a(function(){let e="",t=Be.INSPECT_MAX_BYTES;
 return e=this.toString("hex",0,t).replace(/(.{2})/g,"$1 ").trim(),this.length>t&&(e+=" ... "),"<Buff\
 er "+e+">"},"inspect");Wn&&(h.prototype[Wn]=h.prototype.inspect);h.prototype.compare=a(function(e,t,n,i,s){
 if(ue(e,Uint8Array)&&(e=h.from(e,e.offset,e.byteLength)),!h.isBuffer(e))throw new TypeError('The "ta\
@@ -166,10 +166,10 @@ a(function(e,t){return e=e>>>0,t||q(e,2,this.length),this[e]<<8|this[e+1]},"read
 readUint32LE=h.prototype.readUInt32LE=a(function(e,t){return e=e>>>0,t||q(e,4,this.length),(this[e]|
 this[e+1]<<8|this[e+2]<<16)+this[e+3]*16777216},"readUInt32LE");h.prototype.readUint32BE=h.prototype.
 readUInt32BE=a(function(e,t){return e=e>>>0,t||q(e,4,this.length),this[e]*16777216+(this[e+1]<<16|this[e+
-2]<<8|this[e+3])},"readUInt32BE");h.prototype.readBigUInt64LE=we(a(function(e){e=e>>>0,Be(e,"offset");
+2]<<8|this[e+3])},"readUInt32BE");h.prototype.readBigUInt64LE=we(a(function(e){e=e>>>0,Re(e,"offset");
 let t=this[e],n=this[e+7];(t===void 0||n===void 0)&&je(e,this.length-8);let i=t+this[++e]*2**8+this[++e]*
 2**16+this[++e]*2**24,s=this[++e]+this[++e]*2**8+this[++e]*2**16+n*2**24;return BigInt(i)+(BigInt(s)<<
-BigInt(32))},"readBigUInt64LE"));h.prototype.readBigUInt64BE=we(a(function(e){e=e>>>0,Be(e,"offset");
+BigInt(32))},"readBigUInt64LE"));h.prototype.readBigUInt64BE=we(a(function(e){e=e>>>0,Re(e,"offset");
 let t=this[e],n=this[e+7];(t===void 0||n===void 0)&&je(e,this.length-8);let i=t*2**24+this[++e]*2**16+
 this[++e]*2**8+this[++e],s=this[++e]*2**24+this[++e]*2**16+this[++e]*2**8+n;return(BigInt(i)<<BigInt(
 32))+BigInt(s)},"readBigUInt64BE"));h.prototype.readIntLE=a(function(e,t,n){e=e>>>0,t=t>>>0,n||q(e,t,
@@ -183,10 +183,10 @@ a(function(e,t){e=e>>>0,t||q(e,2,this.length);let n=this[e+1]|this[e]<<8;return 
 n},"readInt16BE");h.prototype.readInt32LE=a(function(e,t){return e=e>>>0,t||q(e,4,this.length),this[e]|
 this[e+1]<<8|this[e+2]<<16|this[e+3]<<24},"readInt32LE");h.prototype.readInt32BE=a(function(e,t){return e=
 e>>>0,t||q(e,4,this.length),this[e]<<24|this[e+1]<<16|this[e+2]<<8|this[e+3]},"readInt32BE");h.prototype.
-readBigInt64LE=we(a(function(e){e=e>>>0,Be(e,"offset");let t=this[e],n=this[e+7];(t===void 0||n===void 0)&&
+readBigInt64LE=we(a(function(e){e=e>>>0,Re(e,"offset");let t=this[e],n=this[e+7];(t===void 0||n===void 0)&&
 je(e,this.length-8);let i=this[e+4]+this[e+5]*2**8+this[e+6]*2**16+(n<<24);return(BigInt(i)<<BigInt(
 32))+BigInt(t+this[++e]*2**8+this[++e]*2**16+this[++e]*2**24)},"readBigInt64LE"));h.prototype.readBigInt64BE=
-we(a(function(e){e=e>>>0,Be(e,"offset");let t=this[e],n=this[e+7];(t===void 0||n===void 0)&&je(e,this.
+we(a(function(e){e=e>>>0,Re(e,"offset");let t=this[e],n=this[e+7];(t===void 0||n===void 0)&&je(e,this.
 length-8);let i=(t<<24)+this[++e]*2**16+this[++e]*2**8+this[++e];return(BigInt(i)<<BigInt(32))+BigInt(
 this[++e]*2**24+this[++e]*2**16+this[++e]*2**8+n)},"readBigInt64BE"));h.prototype.readFloatLE=a(function(e,t){
 return e=e>>>0,t||q(e,4,this.length),Pe.read(this,e,!0,23,4)},"readFloatLE");h.prototype.readFloatBE=
@@ -266,12 +266,12 @@ f range.`,i=t;return Number.isInteger(t)&&Math.abs(t)>2**32?i=$n(String(t)):type
 t),(t>BigInt(2)**BigInt(32)||t<-(BigInt(2)**BigInt(32)))&&(i=$n(i)),i+="n"),n+=` It must be ${e}. Re\
 ceived ${i}`,n},RangeError);function $n(r){let e="",t=r.length,n=r[0]==="-"?1:0;for(;t>=n+4;t-=3)e=`\
 _${r.slice(t-3,t)}${e}`;return`${r.slice(0,t)}${e}`}a($n,"addNumericalSeparator");function Xo(r,e,t){
-Be(e,"offset"),(r[e]===void 0||r[e+t]===void 0)&&je(e,r.length-(t+1))}a(Xo,"checkBounds");function ri(r,e,t,n,i,s){
+Re(e,"offset"),(r[e]===void 0||r[e+t]===void 0)&&je(e,r.length-(t+1))}a(Xo,"checkBounds");function ri(r,e,t,n,i,s){
 if(r>t||r<e){let o=typeof e=="bigint"?"n":"",u;throw s>3?e===0||e===BigInt(0)?u=`>= 0${o} and < 2${o}\
  ** ${(s+1)*8}${o}`:u=`>= -(2${o} ** ${(s+1)*8-1}${o}) and < 2 ** ${(s+1)*8-1}${o}`:u=`>= ${e}${o} a\
-nd <= ${t}${o}`,new Te.ERR_OUT_OF_RANGE("value",u,r)}Xo(n,i,s)}a(ri,"checkIntBI");function Be(r,e){if(typeof r!=
-"number")throw new Te.ERR_INVALID_ARG_TYPE(e,"number",r)}a(Be,"validateNumber");function je(r,e,t){throw Math.
-floor(r)!==r?(Be(r,t),new Te.ERR_OUT_OF_RANGE(t||"offset","an integer",r)):e<0?new Te.ERR_BUFFER_OUT_OF_BOUNDS:
+nd <= ${t}${o}`,new Te.ERR_OUT_OF_RANGE("value",u,r)}Xo(n,i,s)}a(ri,"checkIntBI");function Re(r,e){if(typeof r!=
+"number")throw new Te.ERR_INVALID_ARG_TYPE(e,"number",r)}a(Re,"validateNumber");function je(r,e,t){throw Math.
+floor(r)!==r?(Re(r,t),new Te.ERR_OUT_OF_RANGE(t||"offset","an integer",r)):e<0?new Te.ERR_BUFFER_OUT_OF_BOUNDS:
 new Te.ERR_OUT_OF_RANGE(t||"offset",`>= ${t?1:0} and <= ${e}`,r)}a(je,"boundsError");var ea=/[^+/0-9A-Za-z-_]/g;
 function ta(r){if(r=r.split("=")[0],r=r.trim().replace(ea,""),r.length<2)return"";for(;r.length%4!==
 0;)r=r+"=";return r}a(ta,"base64clean");function Ht(r,e){e=e||1/0;let t,n=r.length,i=null,s=[];for(let o=0;o<
@@ -293,25 +293,25 @@ sa:r}a(we,"defineBigIntMethod");function sa(){throw new Error("BigInt not suppor
 gIntNotDefined")});var b,v,x,d,m,p=G(()=>{"use strict";b=globalThis,v=globalThis.setImmediate??(r=>setTimeout(r,0)),x=globalThis.
 clearImmediate??(r=>clearTimeout(r)),d=typeof globalThis.Buffer=="function"&&typeof globalThis.Buffer.
 allocUnsafe=="function"?globalThis.Buffer:ii().Buffer,m=globalThis.process??{};m.env??(m.env={});try{
-m.nextTick(()=>{})}catch{let e=Promise.resolve();m.nextTick=e.then.bind(e)}});var ge=T((Rl,Kt)=>{"use strict";p();var Le=typeof Reflect=="object"?Reflect:null,si=Le&&typeof Le.apply==
+m.nextTick(()=>{})}catch{let e=Promise.resolve();m.nextTick=e.then.bind(e)}});var ge=T((Bl,Kt)=>{"use strict";p();var Le=typeof Reflect=="object"?Reflect:null,si=Le&&typeof Le.apply==
 "function"?Le.apply:a(function(e,t,n){return Function.prototype.apply.call(e,t,n)},"ReflectApply"),pt;
 Le&&typeof Le.ownKeys=="function"?pt=Le.ownKeys:Object.getOwnPropertySymbols?pt=a(function(e){return Object.
 getOwnPropertyNames(e).concat(Object.getOwnPropertySymbols(e))},"ReflectOwnKeys"):pt=a(function(e){return Object.
 getOwnPropertyNames(e)},"ReflectOwnKeys");function oa(r){console&&console.warn&&console.warn(r)}a(oa,
-"ProcessEmitWarning");var ai=Number.isNaN||a(function(e){return e!==e},"NumberIsNaN");function B(){B.
-init.call(this)}a(B,"EventEmitter");Kt.exports=B;Kt.exports.once=la;B.EventEmitter=B;B.prototype._events=
-void 0;B.prototype._eventsCount=0;B.prototype._maxListeners=void 0;var oi=10;function dt(r){if(typeof r!=
+"ProcessEmitWarning");var ai=Number.isNaN||a(function(e){return e!==e},"NumberIsNaN");function R(){R.
+init.call(this)}a(R,"EventEmitter");Kt.exports=R;Kt.exports.once=la;R.EventEmitter=R;R.prototype._events=
+void 0;R.prototype._eventsCount=0;R.prototype._maxListeners=void 0;var oi=10;function dt(r){if(typeof r!=
 "function")throw new TypeError('The "listener" argument must be of type Function. Received type '+typeof r)}
-a(dt,"checkListener");Object.defineProperty(B,"defaultMaxListeners",{enumerable:!0,get:a(function(){
+a(dt,"checkListener");Object.defineProperty(R,"defaultMaxListeners",{enumerable:!0,get:a(function(){
 return oi},"get"),set:a(function(r){if(typeof r!="number"||r<0||ai(r))throw new RangeError('The valu\
 e of "defaultMaxListeners" is out of range. It must be a non-negative number. Received '+r+".");oi=r},
-"set")});B.init=function(){(this._events===void 0||this._events===Object.getPrototypeOf(this)._events)&&
+"set")});R.init=function(){(this._events===void 0||this._events===Object.getPrototypeOf(this)._events)&&
 (this._events=Object.create(null),this._eventsCount=0),this._maxListeners=this._maxListeners||void 0};
-B.prototype.setMaxListeners=a(function(e){if(typeof e!="number"||e<0||ai(e))throw new RangeError('Th\
+R.prototype.setMaxListeners=a(function(e){if(typeof e!="number"||e<0||ai(e))throw new RangeError('Th\
 e value of "n" is out of range. It must be a non-negative number. Received '+e+".");return this._maxListeners=
-e,this},"setMaxListeners");function ui(r){return r._maxListeners===void 0?B.defaultMaxListeners:r._maxListeners}
-a(ui,"_getMaxListeners");B.prototype.getMaxListeners=a(function(){return ui(this)},"getMaxListeners");
-B.prototype.emit=a(function(e){for(var t=[],n=1;n<arguments.length;n++)t.push(arguments[n]);var i=e===
+e,this},"setMaxListeners");function ui(r){return r._maxListeners===void 0?R.defaultMaxListeners:r._maxListeners}
+a(ui,"_getMaxListeners");R.prototype.getMaxListeners=a(function(){return ui(this)},"getMaxListeners");
+R.prototype.emit=a(function(e){for(var t=[],n=1;n<arguments.length;n++)t.push(arguments[n]);var i=e===
 "error",s=this._events;if(s!==void 0)i=i&&s.error===void 0;else if(!i)return!1;if(i){var o;if(t.length>
 0&&(o=t[0]),o instanceof Error)throw o;var u=new Error("Unhandled error."+(o?" ("+o.message+")":""));
 throw u.context=o,u}var c=s[e];if(c===void 0)return!1;if(typeof c=="function")si(c,this,t);else for(var l=c.
@@ -321,21 +321,21 @@ t),s=r._events,s===void 0?(s=r._events=Object.create(null),r._eventsCount=0):(s.
 "function"?o=s[e]=n?[t,o]:[o,t]:n?o.unshift(t):o.push(t),i=ui(r),i>0&&o.length>i&&!o.warned){o.warned=
 !0;var u=new Error("Possible EventEmitter memory leak detected. "+o.length+" "+String(e)+" listeners\
  added. Use emitter.setMaxListeners() to increase limit");u.name="MaxListenersExceededWarning",u.emitter=
-r,u.type=e,u.count=o.length,oa(u)}return r}a(ci,"_addListener");B.prototype.addListener=a(function(e,t){
-return ci(this,e,t,!1)},"addListener");B.prototype.on=B.prototype.addListener;B.prototype.prependListener=
+r,u.type=e,u.count=o.length,oa(u)}return r}a(ci,"_addListener");R.prototype.addListener=a(function(e,t){
+return ci(this,e,t,!1)},"addListener");R.prototype.on=R.prototype.addListener;R.prototype.prependListener=
 a(function(e,t){return ci(this,e,t,!0)},"prependListener");function aa(){if(!this.fired)return this.
 target.removeListener(this.type,this.wrapFn),this.fired=!0,arguments.length===0?this.listener.call(this.
 target):this.listener.apply(this.target,arguments)}a(aa,"onceWrapper");function li(r,e,t){var n={fired:!1,
 wrapFn:void 0,target:r,type:e,listener:t},i=aa.bind(n);return i.listener=t,n.wrapFn=i,i}a(li,"_onceW\
-rap");B.prototype.once=a(function(e,t){return dt(t),this.on(e,li(this,e,t)),this},"once");B.prototype.
+rap");R.prototype.once=a(function(e,t){return dt(t),this.on(e,li(this,e,t)),this},"once");R.prototype.
 prependOnceListener=a(function(e,t){return dt(t),this.prependListener(e,li(this,e,t)),this},"prepend\
-OnceListener");B.prototype.removeListener=a(function(e,t){var n,i,s,o,u;if(dt(t),i=this._events,i===
+OnceListener");R.prototype.removeListener=a(function(e,t){var n,i,s,o,u;if(dt(t),i=this._events,i===
 void 0)return this;if(n=i[e],n===void 0)return this;if(n===t||n.listener===t)--this._eventsCount===0?
 this._events=Object.create(null):(delete i[e],i.removeListener&&this.emit("removeListener",e,n.listener||
 t));else if(typeof n!="function"){for(s=-1,o=n.length-1;o>=0;o--)if(n[o]===t||n[o].listener===t){u=n[o].
 listener,s=o;break}if(s<0)return this;s===0?n.shift():ua(n,s),n.length===1&&(i[e]=n[0]),i.removeListener!==
-void 0&&this.emit("removeListener",e,u||t)}return this},"removeListener");B.prototype.off=B.prototype.
-removeListener;B.prototype.removeAllListeners=a(function(e){var t,n,i;if(n=this._events,n===void 0)return this;
+void 0&&this.emit("removeListener",e,u||t)}return this},"removeListener");R.prototype.off=R.prototype.
+removeListener;R.prototype.removeAllListeners=a(function(e){var t,n,i;if(n=this._events,n===void 0)return this;
 if(n.removeListener===void 0)return arguments.length===0?(this._events=Object.create(null),this._eventsCount=
 0):n[e]!==void 0&&(--this._eventsCount===0?this._events=Object.create(null):delete n[e]),this;if(arguments.
 length===0){var s=Object.keys(n),o;for(i=0;i<s.length;++i)o=s[i],o!=="removeListener"&&this.removeAllListeners(
@@ -343,11 +343,11 @@ o);return this.removeAllListeners("removeListener"),this._events=Object.create(n
 0,this}if(t=n[e],typeof t=="function")this.removeListener(e,t);else if(t!==void 0)for(i=t.length-1;i>=
 0;i--)this.removeListener(e,t[i]);return this},"removeAllListeners");function fi(r,e,t){var n=r._events;
 if(n===void 0)return[];var i=n[e];return i===void 0?[]:typeof i=="function"?t?[i.listener||i]:[i]:t?
-ca(i):pi(i,i.length)}a(fi,"_listeners");B.prototype.listeners=a(function(e){return fi(this,e,!0)},"l\
-isteners");B.prototype.rawListeners=a(function(e){return fi(this,e,!1)},"rawListeners");B.listenerCount=
-function(r,e){return typeof r.listenerCount=="function"?r.listenerCount(e):hi.call(r,e)};B.prototype.
+ca(i):pi(i,i.length)}a(fi,"_listeners");R.prototype.listeners=a(function(e){return fi(this,e,!0)},"l\
+isteners");R.prototype.rawListeners=a(function(e){return fi(this,e,!1)},"rawListeners");R.listenerCount=
+function(r,e){return typeof r.listenerCount=="function"?r.listenerCount(e):hi.call(r,e)};R.prototype.
 listenerCount=hi;function hi(r){var e=this._events;if(e!==void 0){var t=e[r];if(typeof t=="function")
-return 1;if(t!==void 0)return t.length}return 0}a(hi,"listenerCount");B.prototype.eventNames=a(function(){
+return 1;if(t!==void 0)return t.length}return 0}a(hi,"listenerCount");R.prototype.eventNames=a(function(){
 return this._eventsCount>0?pt(this._events):[]},"eventNames");function pi(r,e){for(var t=new Array(e),
 n=0;n<e;++n)t[n]=r[n];return t}a(pi,"arrayClone");function ua(r,e){for(;e+1<r.length;e++)r[e]=r[e+1];
 r.pop()}a(ua,"spliceOne");function ca(r){for(var e=new Array(r.length),t=0;t<e.length;++t)e[t]=r[t].
@@ -447,19 +447,19 @@ newEntry(),e))return this.entries}else t.value==='"'&&!t.escaped?(i&&this.newEnt
 not balanced");return this.entries}};a(vt,"ArrayParser");var er=vt;function Ca(r){return r}a(Ca,"ide\
 ntity")});var rr=T((Zl,Ci)=>{p();var _a=tr();Ci.exports={create:a(function(r,e){return{parse:a(function(){return _a.
 parse(r,e)},"parse")}},"create")}});var Ti=T((ef,Ii)=>{"use strict";p();var Ia=/(\d{1,})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(\.\d{1,})?.*?( BC)?$/,
-Ta=/^(\d{1,})-(\d{2})-(\d{2})( BC)?$/,Pa=/([Z+-])(\d{2})?:?(\d{2})?:?(\d{2})?/,Ba=/^-?infinity$/;Ii.
-exports=a(function(e){if(Ba.test(e))return Number(e.replace("i","I"));var t=Ia.exec(e);if(!t)return Ra(
+Ta=/^(\d{1,})-(\d{2})-(\d{2})( BC)?$/,Pa=/([Z+-])(\d{2})?:?(\d{2})?:?(\d{2})?/,Ra=/^-?infinity$/;Ii.
+exports=a(function(e){if(Ra.test(e))return Number(e.replace("i","I"));var t=Ia.exec(e);if(!t)return Ba(
 e)||null;var n=!!t[8],i=parseInt(t[1],10);n&&(i=_i(i));var s=parseInt(t[2],10)-1,o=t[3],u=parseInt(t[4],
 10),c=parseInt(t[5],10),l=parseInt(t[6],10),f=t[7];f=f?1e3*parseFloat(f):0;var y,g=La(e);return g!=null?
 (y=new Date(Date.UTC(i,s,o,u,c,l,f)),nr(i)&&y.setUTCFullYear(i),g!==0&&y.setTime(y.getTime()-g)):(y=
-new Date(i,s,o,u,c,l,f),nr(i)&&y.setFullYear(i)),y},"parseDate");function Ra(r){var e=Ta.exec(r);if(e){
+new Date(i,s,o,u,c,l,f),nr(i)&&y.setFullYear(i)),y},"parseDate");function Ba(r){var e=Ta.exec(r);if(e){
 var t=parseInt(e[1],10),n=!!e[4];n&&(t=_i(t));var i=parseInt(e[2],10)-1,s=e[3],o=new Date(t,i,s);return nr(
-t)&&o.setFullYear(t),o}}a(Ra,"getDate");function La(r){if(r.endsWith("+00"))return 0;var e=Pa.exec(r.
+t)&&o.setFullYear(t),o}}a(Ba,"getDate");function La(r){if(r.endsWith("+00"))return 0;var e=Pa.exec(r.
 split(" ")[1]);if(e){var t=e[1];if(t==="Z")return 0;var n=t==="-"?-1:1,i=parseInt(e[2],10)*3600+parseInt(
 e[3]||0,10)*60+parseInt(e[4]||0,10);return i*n*1e3}}a(La,"timeZoneOffset");function _i(r){return-(r-
-1)}a(_i,"bcYearToNegativeYear");function nr(r){return r>=0&&r<100}a(nr,"is0To99")});var Bi=T((nf,Pi)=>{p();Pi.exports=ka;var Fa=Object.prototype.hasOwnProperty;function ka(r){for(var e=1;e<
+1)}a(_i,"bcYearToNegativeYear");function nr(r){return r>=0&&r<100}a(nr,"is0To99")});var Ri=T((nf,Pi)=>{p();Pi.exports=ka;var Fa=Object.prototype.hasOwnProperty;function ka(r){for(var e=1;e<
 arguments.length;e++){var t=arguments[e];for(var n in t)Fa.call(t,n)&&(r[n]=t[n])}return r}a(ka,"ext\
-end")});var Fi=T((af,Li)=>{"use strict";p();var Ma=Bi();Li.exports=ke;function ke(r){if(!(this instanceof ke))
+end")});var Fi=T((af,Li)=>{"use strict";p();var Ma=Ri();Li.exports=ke;function ke(r){if(!(this instanceof ke))
 return new ke(r);Ma(this,Va(r))}a(ke,"PostgresInterval");var Ua=["seconds","minutes","hours","days",
 "months","years"];ke.prototype.toPostgres=function(){var r=Ua.filter(this.hasOwnProperty,this);return this.
 milliseconds&&r.indexOf("seconds")<0&&r.push("seconds"),r.length===0?"0":r.map(function(e){var t=this[e]||
@@ -470,10 +470,10 @@ toISO=function(){var r=Oa.map(t,this).join(""),e=qa.map(t,this).join("");return"
 var i=this[n]||0;return n==="seconds"&&this.milliseconds&&(i=(i+this.milliseconds/1e3).toFixed(6).replace(
 /0+$/,"")),i+Da[n]}};var ir="([+-]?\\d+)",Qa=ir+"\\s+years?",Na=ir+"\\s+mons?",Wa=ir+"\\s+days?",ja="\
 ([+-])?([\\d]*):(\\d\\d):(\\d\\d)\\.?(\\d{1,6})?",Ha=new RegExp([Qa,Na,Wa,ja].map(function(r){return"\
-("+r+")?"}).join("\\s*")),Ri={years:2,months:4,days:6,hours:9,minutes:10,seconds:11,milliseconds:12},
+("+r+")?"}).join("\\s*")),Bi={years:2,months:4,days:6,hours:9,minutes:10,seconds:11,milliseconds:12},
 $a=["hours","minutes","seconds","milliseconds"];function Ga(r){var e=r+"000000".slice(r.length);return parseInt(
 e,10)/1e3}a(Ga,"parseMilliseconds");function Va(r){if(!r)return{};var e=Ha.exec(r),t=e[8]==="-";return Object.
-keys(Ri).reduce(function(n,i){var s=Ri[i],o=e[s];return!o||(o=i==="milliseconds"?Ga(o):parseInt(o,10),
+keys(Bi).reduce(function(n,i){var s=Bi[i],o=e[s];return!o||(o=i==="milliseconds"?Ga(o):parseInt(o,10),
 !o)||(t&&~$a.indexOf(i)&&(o*=-1),n[i]=o),n},{})}a(Va,"parse")});var Mi=T((lf,ki)=>{"use strict";p();ki.exports=a(function(e){if(/^\\x/.test(e))return new d(e.substr(
 2),"hex");for(var t="",n=0;n<e.length;)if(e[n]!=="\\")t+=e[n],++n;else if(/[0-7]{3}/.test(e.substr(n+
 1,3)))t+=String.fromCharCode(parseInt(e.substr(n+1,3),8)),n+=4;else{for(var i=1;n+i<e.length&&e[n+i]===
@@ -554,10 +554,10 @@ c=1541459225,l=0,f=0,y=[1116352408,1899447441,3049323471,3921009573,961987163,15
 1986661051,2177026350,2456956037,2730485921,2820302411,3259730800,3345764771,3516065817,3600352804,4094571909,
 275423344,430227734,506948616,659060556,883997877,958139571,1322822218,1537002063,1747873779,1955562222,
 2024104815,2227730452,2361852424,2428436474,2756734187,3204031479,3329325298],g=a((I,w)=>I>>>w|I<<32-
-w,"rrot"),A=new Uint32Array(64),C=new Uint8Array(64),D=a(()=>{for(let R=0,j=0;R<16;R++,j+=4)A[R]=C[j]<<
-24|C[j+1]<<16|C[j+2]<<8|C[j+3];for(let R=16;R<64;R++){let j=g(A[R-15],7)^g(A[R-15],18)^A[R-15]>>>3,le=g(
-A[R-2],17)^g(A[R-2],19)^A[R-2]>>>10;A[R]=A[R-16]+j+A[R-7]+le|0}let I=e,w=t,Z=n,W=i,J=s,X=o,se=u,oe=c;
-for(let R=0;R<64;R++){let j=g(J,6)^g(J,11)^g(J,25),le=J&X^~J&se,de=oe+j+le+y[R]+A[R]|0,We=g(I,2)^g(I,
+w,"rrot"),A=new Uint32Array(64),C=new Uint8Array(64),D=a(()=>{for(let B=0,j=0;B<16;B++,j+=4)A[B]=C[j]<<
+24|C[j+1]<<16|C[j+2]<<8|C[j+3];for(let B=16;B<64;B++){let j=g(A[B-15],7)^g(A[B-15],18)^A[B-15]>>>3,le=g(
+A[B-2],17)^g(A[B-2],19)^A[B-2]>>>10;A[B]=A[B-16]+j+A[B-7]+le|0}let I=e,w=t,Z=n,W=i,J=s,X=o,se=u,oe=c;
+for(let B=0;B<64;B++){let j=g(J,6)^g(J,11)^g(J,25),le=J&X^~J&se,de=oe+j+le+y[B]+A[B]|0,We=g(I,2)^g(I,
 13)^g(I,22),fe=I&w^I&Z^w&Z,_e=We+fe|0;oe=se,se=X,X=J,J=W+de|0,W=Z,Z=w,w=I,I=de+_e|0}e=e+I|0,t=t+w|0,
 n=n+Z|0,i=i+W|0,s=s+J|0,o=o+X|0,u=u+se|0,c=c+oe|0,f=0},"process"),Y=a(I=>{typeof I=="string"&&(I=new TextEncoder().
 encode(I));for(let w=0;w<I.length;w++)C[f++]=I[w],f===64&&D();l+=I.length},"add"),P=a(()=>{if(C[f++]=
@@ -666,9 +666,9 @@ getUTCDate(),2)+"T"+N(r.getUTCHours(),2)+":"+N(r.getUTCMinutes(),2)+":"+N(r.getU
 r.getUTCMilliseconds(),3);return n+="+00:00",t&&(n+=" BC"),n}a(Tu,"dateToStringUTC");function Pu(r,e,t){
 return r=typeof r=="string"?{text:r}:r,e&&(typeof e=="function"?r.callback=e:r.values=e),t&&(r.callback=
 t),r}a(Pu,"normalizeQueryConfig");var pr=a(function(r){return Eu.createHash("md5").update(r,"utf-8").
-digest("hex")},"md5"),Bu=a(function(r,e,t){var n=pr(e+r),i=pr(d.concat([d.from(n),t]));return"md5"+i},
+digest("hex")},"md5"),Ru=a(function(r,e,t){var n=pr(e+r),i=pr(d.concat([d.from(n),t]));return"md5"+i},
 "postgresMd5PasswordHash");ns.exports={prepareValue:a(function(e){return Ct(e)},"prepareValueWrapper"),
-normalizeQueryConfig:Pu,postgresMd5PasswordHash:Bu,md5:pr}});var nt={};ie(nt,{default:()=>ku});var ku,it=G(()=>{"use strict";p();ku={}});var ds=T((th,ps)=>{"use strict";p();var yr=(fr(),O(lr));function Mu(r){if(r.indexOf("SCRAM-SHA-256")===
+normalizeQueryConfig:Pu,postgresMd5PasswordHash:Ru,md5:pr}});var nt={};ie(nt,{default:()=>ku});var ku,it=G(()=>{"use strict";p();ku={}});var ds=T((th,ps)=>{"use strict";p();var yr=(fr(),O(lr));function Mu(r){if(r.indexOf("SCRAM-SHA-256")===
 -1)throw new Error("SASL: Only mechanism SCRAM-SHA-256 is currently supported");let e=yr.randomBytes(
 18).toString("base64");return{mechanism:"SCRAM-SHA-256",clientNonce:e,response:"n,,n=*,r="+e,message:"\
 SASLInitialResponse"}}a(Mu,"startSession");function Uu(r,e,t){if(r.message!=="SASLInitialResponse")throw new Error(
@@ -760,13 +760,13 @@ t.ssl==="0"&&(t.ssl=!1),(t.sslcert||t.sslkey||t.sslrootcert||t.sslmode)&&(t.ssl=
 cert=Ir.readFileSync(t.sslcert).toString()),t.sslkey&&(t.ssl.key=Ir.readFileSync(t.sslkey).toString()),
 t.sslrootcert&&(t.ssl.ca=Ir.readFileSync(t.sslrootcert).toString()),t.sslmode){case"disable":{t.ssl=
 !1;break}case"prefer":case"require":case"verify-ca":case"verify-full":break;case"no-verify":{t.ssl.rejectUnauthorized=
-!1;break}}return t}a(Tr,"parse");Ts.exports=Tr;Tr.parse=Tr});var Bt=T((Ah,Ls)=>{"use strict";p();var fc=(Is(),O(_s)),Rs=tt(),Bs=Ps().parse,H=a(function(r,e,t){return t===
-void 0?t=m.env["PG"+r.toUpperCase()]:t===!1||(t=m.env[t]),e[r]||t||Rs[r]},"val"),hc=a(function(){switch(m.
+!1;break}}return t}a(Tr,"parse");Ts.exports=Tr;Tr.parse=Tr});var Rt=T((Ah,Ls)=>{"use strict";p();var fc=(Is(),O(_s)),Bs=tt(),Rs=Ps().parse,H=a(function(r,e,t){return t===
+void 0?t=m.env["PG"+r.toUpperCase()]:t===!1||(t=m.env[t]),e[r]||t||Bs[r]},"val"),hc=a(function(){switch(m.
 env.PGSSLMODE){case"disable":return!1;case"prefer":case"require":case"verify-ca":case"verify-full":return!0;case"\
-no-verify":return{rejectUnauthorized:!1}}return Rs.ssl},"readSSLConfigFromEnvironment"),Oe=a(function(r){
+no-verify":return{rejectUnauthorized:!1}}return Bs.ssl},"readSSLConfigFromEnvironment"),Oe=a(function(r){
 return"'"+(""+r).replace(/\\/g,"\\\\").replace(/'/g,"\\'")+"'"},"quoteParamValue"),ne=a(function(r,e,t){
-var n=e[t];n!=null&&r.push(t+"="+Oe(n))},"add"),Br=class Br{constructor(e){e=typeof e=="string"?Bs(e):
-e||{},e.connectionString&&(e=Object.assign({},e,Bs(e.connectionString))),this.user=H("user",e),this.
+var n=e[t];n!=null&&r.push(t+"="+Oe(n))},"add"),Rr=class Rr{constructor(e){e=typeof e=="string"?Rs(e):
+e||{},e.connectionString&&(e=Object.assign({},e,Rs(e.connectionString))),this.user=H("user",e),this.
 database=H("database",e),this.database===void 0&&(this.database=this.user),this.port=parseInt(H("por\
 t",e),10),this.host=H("host",e),Object.defineProperty(this,"password",{configurable:!0,enumerable:!1,
 writable:!0,value:H("password",e)}),this.binary=H("binary",e),this.options=H("options",e),this.ssl=typeof e.
@@ -787,7 +787,7 @@ slkey"),ne(t,n,"sslcert"),ne(t,n,"sslrootcert"),this.database&&t.push("dbname="+
 replication&&t.push("replication="+Oe(this.replication)),this.host&&t.push("host="+Oe(this.host)),this.
 isDomainSocket)return e(null,t.join(" "));this.client_encoding&&t.push("client_encoding="+Oe(this.client_encoding)),
 fc.lookup(this.host,function(i,s){return i?e(i,null):(t.push("hostaddr="+Oe(s)),e(null,t.join(" ")))})}};
-a(Br,"ConnectionParameters");var Pr=Br;Ls.exports=Pr});var Ms=T((Ih,ks)=>{"use strict";p();var pc=Je(),Fs=/^([A-Za-z]+)(?: (\d+))?(?: (\d+))?/,Lr=class Lr{constructor(e,t){
+a(Rr,"ConnectionParameters");var Pr=Rr;Ls.exports=Pr});var Ms=T((Ih,ks)=>{"use strict";p();var pc=Je(),Fs=/^([A-Za-z]+)(?: (\d+))?(?: (\d+))?/,Lr=class Lr{constructor(e,t){
 this.command=null,this.rowCount=null,this.oid=null,this.rows=[],this.fields=[],this._parsers=void 0,
 this._types=t,this.RowCtor=null,this.rowAsArray=e==="array",this.rowAsArray&&(this.parseRow=this._parseRowAsArray)}addCommandComplete(e){
 var t;e.text?t=Fs.exec(e.text):t=Fs.exec(e.command),t&&(this.command=t[1],t[3]?(this.oid=parseInt(t[2],
@@ -797,7 +797,7 @@ for(var t={},n=0,i=e.length;n<i;n++){var s=e[n],o=this.fields[n].name;s!==null?t
 s):t[o]=null}return t}addRow(e){this.rows.push(e)}addFields(e){this.fields=e,this.fields.length&&(this.
 _parsers=new Array(e.length));for(var t=0;t<e.length;t++){var n=e[t];this._types?this._parsers[t]=this.
 _types.getTypeParser(n.dataTypeID,n.format||"text"):this._parsers[t]=pc.getTypeParser(n.dataTypeID,n.
-format||"text")}}};a(Lr,"Result");var Rr=Lr;ks.exports=Rr});var qs=T((Bh,Os)=>{"use strict";p();var{EventEmitter:dc}=ge(),Us=Ms(),Ds=rt(),kr=class kr extends dc{constructor(e,t,n){
+format||"text")}}};a(Lr,"Result");var Br=Lr;ks.exports=Br});var qs=T((Rh,Os)=>{"use strict";p();var{EventEmitter:dc}=ge(),Us=Ms(),Ds=rt(),kr=class kr extends dc{constructor(e,t,n){
 super(),e=Ds.normalizeQueryConfig(e,t,n),this.text=e.text,this.values=e.values,this.rows=e.rows,this.
 types=e.types,this.name=e.name,this.binary=e.binary,this.portal=e.portal||"",this.callback=e.callback,
 this._rowMode=e.rowMode,m.domain&&e.callback&&(this.callback=m.domain.bind(e.callback)),this._result=
@@ -855,7 +855,7 @@ var an=class an{constructor(e,t){this.length=e,this.text=t,this.name="commandCom
 ndCompleteMessage");var Gr=an;_.CommandCompleteMessage=Gr;var un=class un{constructor(e,t){this.length=
 e,this.fields=t,this.name="dataRow",this.fieldCount=t.length}};a(un,"DataRowMessage");var Vr=un;_.DataRowMessage=
 Vr;var cn=class cn{constructor(e,t){this.length=e,this.message=t,this.name="notice"}};a(cn,"NoticeMe\
-ssage");var zr=cn;_.NoticeMessage=zr});var Qs=T(Rt=>{"use strict";p();Object.defineProperty(Rt,"__esModule",{value:!0});Rt.Writer=void 0;var hn=class hn{constructor(e=256){
+ssage");var zr=cn;_.NoticeMessage=zr});var Qs=T(Bt=>{"use strict";p();Object.defineProperty(Bt,"__esModule",{value:!0});Bt.Writer=void 0;var hn=class hn{constructor(e=256){
 this.size=e,this.offset=5,this.headerPosition=0,this.buffer=d.allocUnsafe(e)}ensure(e){if(this.buffer.
 length-this.offset<e){let n=this.buffer,i=n.length+(n.length>>1)+e;this.buffer=d.allocUnsafe(i),n.copy(
 this.buffer)}}addInt32(e){return this.ensure(4),this.buffer[this.offset++]=e>>>24&255,this.buffer[this.
@@ -867,7 +867,7 @@ return this.ensure(t),this.buffer.write(e,this.offset),this.offset+=t,this}add(e
 e.length),e.copy(this.buffer,this.offset),this.offset+=e.length,this}join(e){if(e){this.buffer[this.
 headerPosition]=e;let t=this.offset-(this.headerPosition+1);this.buffer.writeInt32BE(t,this.headerPosition+
 1)}return this.buffer.slice(e?0:5,this.offset)}flush(e){let t=this.join(e);return this.offset=5,this.
-headerPosition=0,this.buffer=d.allocUnsafe(this.size),t}};a(hn,"Writer");var fn=hn;Rt.Writer=fn});var Ws=T(Ft=>{"use strict";p();Object.defineProperty(Ft,"__esModule",{value:!0});Ft.serialize=void 0;
+headerPosition=0,this.buffer=d.allocUnsafe(this.size),t}};a(hn,"Writer");var fn=hn;Bt.Writer=fn});var Ws=T(Ft=>{"use strict";p();Object.defineProperty(Ft,"__esModule",{value:!0});Ft.serialize=void 0;
 var pn=Qs(),F=new pn.Writer,yc=a(r=>{F.addInt16(3).addInt16(0);for(let n of Object.keys(r))F.addCString(
 n).addCString(r[n]);F.addCString("client_encoding").addCString("UTF8");let e=F.addCString("").flush(),
 t=e.length+4;return new pn.Writer().addInt32(t).add(e).flush()},"startup"),mc=a(()=>{let r=d.allocUnsafe(
@@ -890,11 +890,11 @@ F.addInt16(n?1:0),F.flush(66)},"bind"),Ac=d.from([69,0,0,0,9,0,0,0,0,0]),Cc=a(r=
 6),t.writeInt32BE(r,8),t.writeInt32BE(e,12),t},"cancel"),dn=a((r,e)=>{let n=4+d.byteLength(e)+1,i=d.
 allocUnsafe(1+n);return i[0]=r,i.writeInt32BE(n,1),i.write(e,5,"utf-8"),i[n]=0,i},"cstringMessage"),
 Ic=F.addCString("P").flush(68),Tc=F.addCString("S").flush(68),Pc=a(r=>r.name?dn(68,`${r.type}${r.name||
-""}`):r.type==="P"?Ic:Tc,"describe"),Bc=a(r=>{let e=`${r.type}${r.name||""}`;return dn(67,e)},"close"),
-Rc=a(r=>F.add(r).flush(100),"copyData"),Lc=a(r=>dn(102,r),"copyFail"),Lt=a(r=>d.from([r,0,0,0,4]),"c\
+""}`):r.type==="P"?Ic:Tc,"describe"),Rc=a(r=>{let e=`${r.type}${r.name||""}`;return dn(67,e)},"close"),
+Bc=a(r=>F.add(r).flush(100),"copyData"),Lc=a(r=>dn(102,r),"copyFail"),Lt=a(r=>d.from([r,0,0,0,4]),"c\
 odeOnlyBuffer"),Fc=Lt(72),kc=Lt(83),Mc=Lt(88),Uc=Lt(99),Dc={startup:yc,password:wc,requestSsl:mc,sendSASLInitialResponseMessage:gc,
-sendSCRAMClientFinalMessage:bc,query:vc,parse:xc,bind:Ec,execute:Cc,describe:Pc,close:Bc,flush:a(()=>Fc,
-"flush"),sync:a(()=>kc,"sync"),end:a(()=>Mc,"end"),copyData:Rc,copyDone:a(()=>Uc,"copyDone"),copyFail:Lc,
+sendSCRAMClientFinalMessage:bc,query:vc,parse:xc,bind:Ec,execute:Cc,describe:Pc,close:Rc,flush:a(()=>Fc,
+"flush"),sync:a(()=>kc,"sync"),end:a(()=>Mc,"end"),copyData:Bc,copyDone:a(()=>Uc,"copyDone"),copyFail:Lc,
 cancel:_c};Ft.serialize=Dc});var js=T(kt=>{"use strict";p();Object.defineProperty(kt,"__esModule",{value:!0});kt.BufferReader=void 0;
 var Oc=d.allocUnsafe(0),mn=class mn{constructor(e=0){this.offset=e,this.buffer=Oc,this.encoding="utf\
 -8"}setBuffer(e,t){this.offset=e,this.buffer=t}int16(){let e=this.buffer.readInt16BE(this.offset);return this.
@@ -987,7 +987,7 @@ this.stream.end();return}return this.stream.write(Kc,()=>{this.stream.end()})}cl
 close(e))}describe(e){this._send(Q.describe(e))}sendCopyFromChunk(e){this._send(Q.copyData(e))}endCopyFrom(){
 this._send(Q.copyDone())}sendCopyFail(e){this._send(Q.copyFail(e))}};a(Sn,"Connection");var xn=Sn;Zs.
 exports=xn});var eo=T((np,Xs)=>{"use strict";p();var Yc=ge().EventEmitter,rp=(it(),O(nt)),Zc=rt(),An=ds(),Jc=Cs(),
-Xc=At(),el=Bt(),Js=qs(),tl=tt(),rl=En(),Cn=class Cn extends Yc{constructor(e){super(),this.connectionParameters=
+Xc=At(),el=Rt(),Js=qs(),tl=tt(),rl=En(),Cn=class Cn extends Yc{constructor(e){super(),this.connectionParameters=
 new el(e),this.user=this.connectionParameters.user,this.database=this.connectionParameters.database,
 this.port=this.connectionParameters.port,this.host=this.connectionParameters.host,Object.defineProperty(
 this,"password",{configurable:!0,enumerable:!1,writable:!0,value:this.connectionParameters.password}),
@@ -1087,7 +1087,7 @@ return{callback:e,result:void 0};let t,n,i=a(function(o,u){o?t(o):n(u)},"cb"),s=
 n=o,t=u}).catch(o=>{throw Error.captureStackTrace(o),o});return{callback:i,result:s}}a(Dt,"promisify");
 function sl(r,e){return a(function t(n){n.client=e,e.removeListener("error",t),e.on("error",()=>{r.log(
 "additional client error after disconnection due to error",n)}),r._remove(e),r.emit("error",n,e)},"i\
-dleListener")}a(sl,"makeIdleListener");var Bn=class Bn extends nl{constructor(e,t){super(),this.options=
+dleListener")}a(sl,"makeIdleListener");var Rn=class Rn extends nl{constructor(e,t){super(),this.options=
 Object.assign({},e),e!=null&&"password"in e&&Object.defineProperty(this.options,"password",{configurable:!0,
 enumerable:!1,writable:!0,value:e.password}),e!=null&&e.ssl&&e.ssl.key&&Object.defineProperty(this.options.
 ssl,"key",{enumerable:!1}),this.options.max=this.options.max||this.options.poolSize||10,this.options.
@@ -1143,7 +1143,7 @@ if(this.log("ending"),this.ending){let n=new Error("Called end on pool more than
 this.Promise.reject(n)}this.ending=!0;let t=Dt(this.Promise,e);return this._endCallback=t.callback,this.
 _pulseQueue(),t.result}get waitingCount(){return this._pendingQueue.length}get idleCount(){return this.
 _idle.length}get expiredCount(){return this._clients.reduce((e,t)=>e+(this._expired.has(t)?1:0),0)}get totalCount(){
-return this._clients.length}};a(Bn,"Pool");var In=Bn;no.exports=In});var so={};ie(so,{default:()=>ol});var ol,oo=G(()=>{"use strict";p();ol={}});var ao=T((lp,al)=>{al.exports={name:"pg",version:"8.8.0",description:"PostgreSQL client - pure javas\
+return this._clients.length}};a(Rn,"Pool");var In=Rn;no.exports=In});var so={};ie(so,{default:()=>ol});var ol,oo=G(()=>{"use strict";p();ol={}});var ao=T((lp,al)=>{al.exports={name:"pg",version:"8.8.0",description:"PostgreSQL client - pure javas\
 cript & libpq with the same API",keywords:["database","libpq","pg","postgre","postgres","postgresql",
 "rdbms"],homepage:"https://github.com/brianc/node-postgres",repository:{type:"git",url:"git://github\
 .com/brianc/node-postgres.git",directory:"packages/pg"},author:"Brian Carlson <brian.m.carlson@gmail\
@@ -1152,8 +1152,8 @@ ing":"^2.5.0","pg-pool":"^3.5.2","pg-protocol":"^1.5.0","pg-types":"^2.1.0",pgpa
 async:"2.6.4",bluebird:"3.5.2",co:"4.6.0","pg-copy-streams":"0.3.0"},peerDependencies:{"pg-native":"\
 >=3.0.1"},peerDependenciesMeta:{"pg-native":{optional:!0}},scripts:{test:"make test-all"},files:["li\
 b","SPONSORS.md"],license:"MIT",engines:{node:">= 8.0.0"},gitHead:"c99fb2c127ddf8d712500db2c7b9a5491\
-a178655"}});var lo=T((fp,co)=>{"use strict";p();var uo=ge().EventEmitter,ul=(it(),O(nt)),Rn=rt(),Ne=co.exports=function(r,e,t){
-uo.call(this),r=Rn.normalizeQueryConfig(r,e,t),this.text=r.text,this.values=r.values,this.name=r.name,
+a178655"}});var lo=T((fp,co)=>{"use strict";p();var uo=ge().EventEmitter,ul=(it(),O(nt)),Bn=rt(),Ne=co.exports=function(r,e,t){
+uo.call(this),r=Bn.normalizeQueryConfig(r,e,t),this.text=r.text,this.values=r.values,this.name=r.name,
 this.callback=r.callback,this.state="new",this._arrayMode=r.rowMode==="array",this._emitRowEvents=!1,
 this.on("newListener",function(n){n==="row"&&(this._emitRowEvents=!0)}.bind(this))};ul.inherits(Ne,uo);
 var cl={sqlState:"code",statementPosition:"position",messagePrimary:"message",context:"where",schemaName:"\
@@ -1170,14 +1170,14 @@ this.native=r.native,r.native.arrayMode=this._arrayMode;var t=a(function(s,o,u){
 nd",e.emit("end",u),e.callback&&e.callback(null,u)},"after");if(m.domain&&(t=m.domain.bind(t)),this.
 name){this.name.length>63&&(console.error("Warning! Postgres only supports 63 characters for query n\
 ames."),console.error("You supplied %s (%s)",this.name,this.name.length),console.error("This can cau\
-se conflicts and silent errors executing queries"));var n=(this.values||[]).map(Rn.prepareValue);if(r.
+se conflicts and silent errors executing queries"));var n=(this.values||[]).map(Bn.prepareValue);if(r.
 namedQueries[this.name]){if(this.text&&r.namedQueries[this.name]!==this.text){let s=new Error(`Prepa\
 red statements must be unique - '${this.name}' was used for a different statement`);return t(s)}return r.
 native.execute(this.name,n,t)}return r.native.prepare(this.name,this.text,n.length,function(s){return s?
 t(s):(r.namedQueries[e.name]=e.text,e.native.execute(e.name,n,t))})}else if(this.values){if(!Array.isArray(
-this.values)){let s=new Error("Query values must be an array");return t(s)}var i=this.values.map(Rn.
+this.values)){let s=new Error("Query values must be an array");return t(s)}var i=this.values.map(Bn.
 prepareValue);r.native.query(this.text,i,t)}else r.native.query(this.text,t)}});var yo=T((yp,po)=>{"use strict";p();var ll=(oo(),O(so)),fl=At(),dp=ao(),fo=ge().EventEmitter,hl=(it(),O(nt)),
-pl=Bt(),ho=lo(),K=po.exports=function(r){fo.call(this),r=r||{},this._Promise=r.Promise||b.Promise,this.
+pl=Rt(),ho=lo(),K=po.exports=function(r){fo.call(this),r=r||{},this._Promise=r.Promise||b.Promise,this.
 _types=new fl(r.types),this.native=new ll({types:this._types}),this._queryQueue=[],this._ending=!1,this.
 _connecting=!1,this._connected=!1,this._queryable=!0;var e=this.connectionParameters=new pl(r);this.
 user=e.user,Object.defineProperty(this,"password",{configurable:!0,enumerable:!1,writable:!0,value:e.
@@ -1262,7 +1262,7 @@ E(this,"code");E(this,"detail");E(this,"hint");E(this,"position");E(this,"intern
 E(this,"constraint");E(this,"file");E(this,"line");E(this,"routine");E(this,"sourceError");"captureS\
 tackTrace"in Error&&typeof Error.captureStackTrace=="function"&&Error.captureStackTrace(this,_t)}};a(
 _t,"NeonDbError");var be=_t,is="transaction() expects an array of queries, or a function returning a\
-n array of queries",Ru=["severity","code","detail","hint","position","internalPosition","internalQue\
+n array of queries",Bu=["severity","code","detail","hint","position","internalPosition","internalQue\
 ry","where","schema","table","column","dataType","constraint","file","line","routine"];function Lu(r){
 return r instanceof d?"\\x"+Ei(r):r}a(Lu,"encodeBuffersAsBytea");function ss(r){let{query:e,params:t}=r instanceof
 $e?r.toParameterizedQuery():r;return{query:e,params:t.map(n=>Lu((0,us.prepareValue)(n)))}}a(ss,"prep\
@@ -1280,14 +1280,14 @@ Y,new $e(P,I))}a(D,"templateFn"),D.query=(P,I,w)=>new Ce(Y,{query:P,params:I??[]
 P),D.transaction=async(P,I)=>{if(typeof P=="function"&&(P=P(D)),!Array.isArray(P))throw new Error(is);
 P.forEach(W=>{if(!(W instanceof Ce))throw new Error(is)});let w=P.map(W=>W.queryData),Z=P.map(W=>W.opts??
 {});return Y(w,Z,I)};async function Y(P,I,w){let{fetchEndpoint:Z,fetchFunction:W}=ce,J=Array.isArray(
-P)?{queries:P.map(ee=>ss(ee))}:ss(P),X=n??{},se=e??!1,oe=t??!1,R=i,j=s,le=o;w!==void 0&&(w.fetchOptions!==
+P)?{queries:P.map(ee=>ss(ee))}:ss(P),X=n??{},se=e??!1,oe=t??!1,B=i,j=s,le=o;w!==void 0&&(w.fetchOptions!==
 void 0&&(X={...X,...w.fetchOptions}),w.arrayMode!==void 0&&(se=w.arrayMode),w.fullResults!==void 0&&
-(oe=w.fullResults),w.isolationLevel!==void 0&&(R=w.isolationLevel),w.readOnly!==void 0&&(j=w.readOnly),
+(oe=w.fullResults),w.isolationLevel!==void 0&&(B=w.isolationLevel),w.readOnly!==void 0&&(j=w.readOnly),
 w.deferrable!==void 0&&(le=w.deferrable)),I!==void 0&&!Array.isArray(I)&&I.fetchOptions!==void 0&&(X=
 {...X,...I.fetchOptions});let de=u;!Array.isArray(I)&&I?.authToken!==void 0&&(de=I.authToken);let We=typeof Z==
 "function"?Z(g,A,{jwtAuth:de!==void 0}):Z,fe={"Neon-Connection-String":r,"Neon-Raw-Text-Output":"tru\
 e","Neon-Array-Mode":"true"},_e=await Fu(de);_e&&(fe.Authorization=`Bearer ${_e}`),Array.isArray(P)&&
-(R!==void 0&&(fe["Neon-Batch-Isolation-Level"]=R),j!==void 0&&(fe["Neon-Batch-Read-Only"]=String(j)),
+(B!==void 0&&(fe["Neon-Batch-Isolation-Level"]=B),j!==void 0&&(fe["Neon-Batch-Read-Only"]=String(j)),
 le!==void 0&&(fe["Neon-Batch-Deferrable"]=String(le))),c||ce.disableWarningInBrowsers||bt();let ye;try{
 ye=await(W??fetch)(We,{method:"POST",body:JSON.stringify(J),headers:fe,...X})}catch(ee){let M=new be(
 `Error connecting to database: ${ee}`);throw M.sourceError=ee,M}if(ye.ok){let ee=await ye.json();if(Array.
@@ -1295,7 +1295,7 @@ isArray(P)){let M=ee.results;if(!Array.isArray(M))throw new be("Neon internal er
 lt format");return M.map(($,me)=>{let Ot=I[me]??{},vo=Ot.arrayMode??se,xo=Ot.fullResults??oe;return os(
 $,{arrayMode:vo,fullResults:xo,types:Ot.types})})}else{let M=I??{},$=M.arrayMode??se,me=M.fullResults??
 oe;return os(ee,{arrayMode:$,fullResults:me,types:M.types})}}else{let{status:ee}=ye;if(ee===400){let M=await ye.
-json(),$=new be(M.message);for(let me of Ru)$[me]=M[me]??void 0;throw $}else{let M=await ye.text();throw new be(
+json(),$=new be(M.message);for(let me of Bu)$[me]=M[me]??void 0;throw $}else{let M=await ye.text();throw new be(
 `Server error (HTTP status ${ee}): ${M}`)}}}return a(Y,"execute"),D}a(cs,"neon");var dr=class dr{constructor(e,t,n){
 this.execute=e;this.queryData=t;this.opts=n}then(e,t){return this.execute(this.queryData,this.opts).
 then(e,t)}catch(e){return this.execute(this.queryData,this.opts).catch(e)}finally(e){return this.execute(
@@ -1338,14 +1338,14 @@ length===i.clientNonce.length)throw new Error("SASL: SCRAM-SERVER-FIRST-MESSAGE:
 [g,d.from([0,0,0,1])]))),P=Y;for(var I=0;I<y-1;I++)Y=new Uint8Array(await n.sign("HMAC",D,Y)),P=d.from(
 P.map((M,$)=>P[$]^Y[$]));let w=P,Z=await n.importKey("raw",w,{name:"HMAC",hash:{name:"SHA-256"}},!1,
 ["sign"]),W=new Uint8Array(await n.sign("HMAC",Z,A.encode("Client Key"))),J=await n.digest("SHA-256",
-W),X="n=*,r="+i.clientNonce,se="r="+c+",s="+l+",i="+y,oe="c=biws,r="+c,R=X+","+se+","+oe,j=await n.importKey(
+W),X="n=*,r="+i.clientNonce,se="r="+c+",s="+l+",i="+y,oe="c=biws,r="+c,B=X+","+se+","+oe,j=await n.importKey(
 "raw",J,{name:"HMAC",hash:{name:"SHA-256"}},!1,["sign"]);var le=new Uint8Array(await n.sign("HMAC",j,
-A.encode(R))),de=d.from(W.map((M,$)=>W[$]^le[$])),We=de.toString("base64");let fe=await n.importKey(
+A.encode(B))),de=d.from(W.map((M,$)=>W[$]^le[$])),We=de.toString("base64");let fe=await n.importKey(
 "raw",w,{name:"HMAC",hash:{name:"SHA-256"}},!1,["sign"]),_e=await n.sign("HMAC",fe,A.encode("Server \
 Key")),ye=await n.importKey("raw",_e,{name:"HMAC",hash:{name:"SHA-256"}},!1,["sign"]);var ee=d.from(
-await n.sign("HMAC",ye,A.encode(R)));i.message="SASLResponse",i.serverSignature=ee.toString("base64"),
+await n.sign("HMAC",ye,A.encode(B)));i.message="SASLResponse",i.serverSignature=ee.toString("base64"),
 i.response=oe+",p="+We,this.connection.sendSCRAMClientFinalMessage(this.saslSession.response)}};a(kn,
-"NeonClient");var ut=kn;Fe();var bo=Se(Bt());function vl(r,e){if(e)return{callback:e,result:void 0};let t,n,i=a(function(o,u){o?t(o):n(u)},"cb"),
+"NeonClient");var ut=kn;Fe();var bo=Se(Rt());function vl(r,e){if(e)return{callback:e,result:void 0};let t,n,i=a(function(o,u){o?t(o):n(u)},"cb"),
 s=new r(function(o,u){n=o,t=u});return{callback:i,result:s}}a(vl,"promisify");var Un=class Un extends go.Pool{constructor(){
 super(...arguments);E(this,"Client",ut);E(this,"hasFetchUnsupportedListeners",!1);E(this,"addListene\
 r",this.on)}on(t,n){return t!=="error"&&(this.hasFetchUnsupportedListeners=!0),super.on(t,n)}query(t,n,i){

--- a/jsr.json
+++ b/jsr.json
@@ -2,10 +2,6 @@
   "name": "@neon/serverless",
   "version": "1.0.2",
   "exports": "./index.mjs",
-  "imports": {
-    "pg": "npm:@types/pg@^8.8.0",
-    "node": "npm:@types/node@^22.15.30"
-  },
   "publish": {
     "include": [
       "index.mjs",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "postversion": "git push --follow-tags origin release/v$npm_package_version && echo 'Release $npm_package_version created. Run `npm publish` and `npx jsr publish` once PR is merged into `main`.'",
     "format": "prettier -c .",
     "format:fix": "prettier -w .",
-    "test": "touch src && npm run test:node && npm run test:edge && npm run test:bun && npm run test:deno && npm run test:packages && npm run test:cloudflare && npm run test:vercel && npm run test:browser",
+    "test": "touch src && npm run test:type-shims && npm run test:node && npm run test:edge && npm run test:bun && npm run test:deno && npm run test:packages && npm run test:cloudflare && npm run test:vercel && npm run test:browser",
+    "test:type-shims": "tsc --noEmit --strict --moduleResolution node --module es2022 --target es2022 tests/type-compatibility.ts",
     "test:node": "npm run build && vitest run --dir=tests/cli --environment=node --typecheck --config=tests/vite.config.mts",
     "test:edge": "npm run build && vitest run --dir=tests/cli --environment=edge-runtime --config=tests/vite.config.mts",
     "test:bun": "npm run build && bun run --env-file=.env.test tests/basic/basic.ts",
@@ -60,11 +61,9 @@
     "test:vercel": "npm run build && vitest run --dir=tests/vercel --config=tests/vite.config.mts",
     "test:browser": "npm run build && playwright install --with-deps firefox chromium && vitest run --dir=tests/browser --browser --config=tests/browser/vite.config.mts"
   },
-  "dependencies": {
-    "@types/node": "^22.15.30",
-    "@types/pg": "^8.8.0"
-  },
   "devDependencies": {
+    "@types/node": "^22.15.30",
+    "@types/pg": "^8.8.0",
     "@cloudflare/workers-types": "^4.20241230.0",
     "@edge-runtime/vm": "^5.0.0",
     "@microsoft/api-extractor": "^7.48.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "format": "prettier -c .",
     "format:fix": "prettier -w .",
     "test": "touch src && npm run test:type-shims && npm run test:node && npm run test:edge && npm run test:bun && npm run test:deno && npm run test:packages && npm run test:cloudflare && npm run test:vercel && npm run test:browser",
-    "test:type-shims": "tsc --noEmit --strict --moduleResolution node --module es2022 --target es2022 tests/type-compatibility.ts",
+    "test:type-shims": "npm run build && tsc --noEmit --strict --moduleResolution node --module es2022 --target es2022 tests/type-compatibility.ts",
     "test:node": "npm run build && vitest run --dir=tests/cli --environment=node --typecheck --config=tests/vite.config.mts",
     "test:edge": "npm run build && vitest run --dir=tests/cli --environment=edge-runtime --config=tests/vite.config.mts",
     "test:bun": "npm run build && bun run --env-file=.env.test tests/basic/basic.ts",

--- a/src/shims/events/index.d.ts
+++ b/src/shims/events/index.d.ts
@@ -1,0 +1,42 @@
+// Minimal EventEmitter type declaration. Replaces the events module from
+// `@types/node` as a runtime dependency. Resolved by via tsconfig paths
+// and inlined by api-extractor.
+
+export class EventEmitter {
+  addListener(
+    eventName: string | symbol,
+    listener: (...args: any[]) => void,
+  ): this;
+  on(
+    eventName: string | symbol,
+    listener: (...args: any[]) => void,
+  ): this;
+  once(
+    eventName: string | symbol,
+    listener: (...args: any[]) => void,
+  ): this;
+  removeListener(
+    eventName: string | symbol,
+    listener: (...args: any[]) => void,
+  ): this;
+  off(
+    eventName: string | symbol,
+    listener: (...args: any[]) => void,
+  ): this;
+  removeAllListeners(event?: string | symbol): this;
+  setMaxListeners(n: number): this;
+  getMaxListeners(): number;
+  listeners(eventName: string | symbol): Function[];
+  rawListeners(eventName: string | symbol): Function[];
+  emit(eventName: string | symbol, ...args: any[]): boolean;
+  listenerCount(eventName: string | symbol): number;
+  prependListener(
+    eventName: string | symbol,
+    listener: (...args: any[]) => void,
+  ): this;
+  prependOnceListener(
+    eventName: string | symbol,
+    listener: (...args: any[]) => void,
+  ): this;
+  eventNames(): Array<string | symbol>;
+}

--- a/src/shims/net/index.ts
+++ b/src/shims/net/index.ts
@@ -684,7 +684,7 @@ export class Socket extends EventEmitter {
   }
 
   write(
-    data: Buffer | string,
+    data: Uint8Array | string,
     encoding = 'utf8',
     callback = (err?: any) => {},
   ) {
@@ -694,7 +694,7 @@ export class Socket extends EventEmitter {
     }
 
     if (typeof data === 'string')
-      data = Buffer.from(data, encoding as BufferEncoding) as unknown as Buffer;
+      data = Buffer.from(data, encoding as BufferEncoding);
 
     if (this.tlsState === TlsState.None) {
       debug && log('sending data direct:', data);
@@ -716,7 +716,7 @@ export class Socket extends EventEmitter {
   }
 
   end(
-    data: Buffer | string = Buffer.alloc(0) as unknown as Buffer,
+    data: Uint8Array | string = Buffer.alloc(0) as unknown as Uint8Array,
     encoding = 'utf8',
     callback = () => {},
   ) {

--- a/src/shims/pg/index.d.ts
+++ b/src/shims/pg/index.d.ts
@@ -103,8 +103,18 @@ export interface PoolConfig extends ClientConfig {
   Client?: (new () => ClientBase) | undefined;
 }
 
+// Keep this aligned with pg-types TypeId enum values.
+type PgTypeId =
+  | 16 | 17 | 18 | 20 | 21 | 23 | 24 | 25 | 26 | 27 | 28 | 29
+  | 114 | 142 | 194 | 210 | 602 | 604 | 650 | 700 | 701 | 702 | 703 | 704
+  | 718 | 774 | 790 | 829 | 869 | 1033 | 1042 | 1043 | 1082 | 1083
+  | 1114 | 1184 | 1186 | 1266 | 1560 | 1562 | 1700 | 1790 | 2202 | 2203
+  | 2204 | 2205 | 2206 | 2950 | 2970 | 3220 | 3361 | 3402 | 3614 | 3615
+  | 3642 | 3734 | 3769 | 3802 | 4089 | 4096;
+type PgTypeFormat = 'text' | 'binary';
+
 export interface CustomTypesConfig {
-  getTypeParser: (id: number, format?: string) => any;
+  getTypeParser: (id: PgTypeId, format?: PgTypeFormat) => any;
 }
 
 // -- Message types ----------------------------------------------------------

--- a/src/shims/pg/index.d.ts
+++ b/src/shims/pg/index.d.ts
@@ -136,6 +136,29 @@ export interface Notification {
   payload?: string | undefined;
 }
 
+// Kept local to avoid depending on pg-protocol declaration files.
+export interface NoticeMessage {
+  readonly name: 'notice';
+  readonly length: number;
+  readonly message: string | undefined;
+  severity: string | undefined;
+  code: string | undefined;
+  detail: string | undefined;
+  hint: string | undefined;
+  position: string | undefined;
+  internalPosition: string | undefined;
+  internalQuery: string | undefined;
+  where: string | undefined;
+  schema: string | undefined;
+  table: string | undefined;
+  column: string | undefined;
+  dataType: string | undefined;
+  constraint: string | undefined;
+  file: string | undefined;
+  line: string | undefined;
+  routine: string | undefined;
+}
+
 export interface BindConfig {
   portal?: string | undefined;
   statement?: string | undefined;
@@ -218,6 +241,7 @@ export class ClientBase extends EventEmitter {
   getTypeParser(id: PgTypeId, format?: PgTypeFormat): any;
   on(event: 'drain', listener: () => void): this;
   on(event: 'error', listener: (err: Error) => void): this;
+  on(event: 'notice', listener: (notice: NoticeMessage) => void): this;
   on(event: 'notification', listener: (message: Notification) => void): this;
   on(event: 'end', listener: () => void): this;
 }

--- a/src/shims/pg/index.d.ts
+++ b/src/shims/pg/index.d.ts
@@ -100,17 +100,18 @@ export interface PoolConfig extends ClientConfig {
   allowExitOnIdle?: boolean | undefined;
   maxUses?: number | undefined;
   maxLifetimeSeconds?: number | undefined;
-  Client?: (new () => ClientBase) | undefined;
+  Client?: (new () => any) | undefined;
 }
 
-// Keep this aligned with pg-types TypeId enum values.
-type PgTypeId =
-  | 16 | 17 | 18 | 20 | 21 | 23 | 24 | 25 | 26 | 27 | 28 | 29
-  | 114 | 142 | 194 | 210 | 602 | 604 | 650 | 700 | 701 | 702 | 703 | 704
-  | 718 | 774 | 790 | 829 | 869 | 1033 | 1042 | 1043 | 1082 | 1083
-  | 1114 | 1184 | 1186 | 1266 | 1560 | 1562 | 1700 | 1790 | 2202 | 2203
-  | 2204 | 2205 | 2206 | 2950 | 2970 | 3220 | 3361 | 3402 | 3614 | 3615
-  | 3642 | 3734 | 3769 | 3802 | 4089 | 4096;
+export interface PoolOptions extends PoolConfig {
+  max: number;
+  maxUses: number;
+  allowExitOnIdle: boolean;
+  maxLifetimeSeconds: number;
+  idleTimeoutMillis: number | null;
+}
+
+type PgTypeId = number;
 type PgTypeFormat = 'text' | 'binary';
 
 export interface CustomTypesConfig {
@@ -204,8 +205,17 @@ export class ClientBase extends EventEmitter {
   ): void;
   pauseDrain(): void;
   resumeDrain(): void;
+  copyFrom(queryText: string): any;
+  copyTo(queryText: string): any;
   escapeIdentifier(str: string): string;
   escapeLiteral(str: string): string;
+  setTypeParser(id: PgTypeId, parseFn: (value: string) => any): void;
+  setTypeParser(
+    id: PgTypeId,
+    format: PgTypeFormat,
+    parseFn: (value: string) => any,
+  ): void;
+  getTypeParser(id: PgTypeId, format?: PgTypeFormat): any;
   on(event: 'drain', listener: () => void): this;
   on(event: 'error', listener: (err: Error) => void): this;
   on(event: 'notification', listener: (message: Notification) => void): this;
@@ -231,7 +241,7 @@ export interface PoolClient extends ClientBase {
 
 export class Pool extends EventEmitter {
   constructor(config?: PoolConfig);
-  options: PoolConfig;
+  options: PoolOptions;
   readonly totalCount: number;
   readonly idleCount: number;
   readonly waitingCount: number;

--- a/src/shims/pg/index.d.ts
+++ b/src/shims/pg/index.d.ts
@@ -360,6 +360,26 @@ export class DatabaseError extends Error {
   constructor(message: string, length: number, name: string);
 }
 
+export class Result<R extends QueryResultRow = any> implements QueryResult<R> {
+  command: string;
+  rowCount: number | null;
+  oid: number;
+  fields: FieldDef[];
+  rows: R[];
+  constructor(rowMode: string, types: CustomTypesConfig);
+}
+
+export class TypeOverrides implements CustomTypesConfig {
+  constructor(types?: CustomTypesConfig);
+  setTypeParser(id: PgTypeId, parseFn: (value: string) => any): void;
+  setTypeParser(
+    id: PgTypeId,
+    format: PgTypeFormat,
+    parseFn: (value: string | Uint8Array) => any,
+  ): void;
+  getTypeParser(id: PgTypeId, format?: PgTypeFormat): any;
+}
+
 // -- Value exports ----------------------------------------------------------
 
 export declare const types: {
@@ -378,3 +398,6 @@ export declare const defaults: Defaults & ClientConfig;
 
 export declare function escapeIdentifier(str: string): string;
 export declare function escapeLiteral(str: string): string;
+
+import type * as Pg from './index.d.ts';
+export declare const native: typeof Pg | null;

--- a/src/shims/pg/index.d.ts
+++ b/src/shims/pg/index.d.ts
@@ -1,0 +1,336 @@
+/**
+ * Minimal `pg` type declarations, replacing @types/pg as a runtime dependency.
+ * They are resolved via tsconfig paths and inlined by api-extractor.
+ *
+ * esbuild ignores tsconfig paths, so the real `pg` module from node_modules
+ * is still used for the runtime bundle.
+ */
+
+import { EventEmitter } from 'events';
+
+// -- Query types ------------------------------------------------------------
+
+export type QueryConfigValues<T> = T extends Array<infer U> ? T : never;
+
+export interface QueryConfig<I = any[]> {
+  name?: string | undefined;
+  text: string;
+  values?: QueryConfigValues<I>;
+  types?: CustomTypesConfig | undefined;
+}
+
+export interface QueryArrayConfig<I = any[]> extends QueryConfig<I> {
+  rowMode: 'array';
+}
+
+export interface QueryResultBase {
+  command: string;
+  rowCount: number | null;
+  oid: number;
+  fields: FieldDef[];
+}
+
+export interface QueryResultRow {
+  [column: string]: any;
+}
+
+export interface QueryResult<R extends QueryResultRow = any>
+  extends QueryResultBase {
+  rows: R[];
+}
+
+export interface QueryArrayResult<R extends any[] = any[]>
+  extends QueryResultBase {
+  rows: R[];
+}
+
+export interface ResultBuilder<R extends QueryResultRow = any>
+  extends QueryResult<R> {
+  addRow(row: R): void;
+}
+
+export interface QueryParse {
+  name: string;
+  text: string;
+  types: string[];
+}
+
+// -- Config types -----------------------------------------------------------
+
+export interface ClientConfig {
+  user?: string | undefined;
+  database?: string | undefined;
+  password?: string | (() => string | Promise<string>) | undefined;
+  port?: number | undefined;
+  host?: string | undefined;
+  connectionString?: string | undefined;
+  keepAlive?: boolean | undefined;
+  stream?: (() => any) | undefined;
+  statement_timeout?: false | number | undefined;
+  ssl?: boolean | object | undefined;
+  query_timeout?: number | undefined;
+  lock_timeout?: number | undefined;
+  keepAliveInitialDelayMillis?: number | undefined;
+  idle_in_transaction_session_timeout?: number | undefined;
+  application_name?: string | undefined;
+  fallback_application_name?: string | undefined;
+  connectionTimeoutMillis?: number | undefined;
+  types?: CustomTypesConfig | undefined;
+  options?: string | undefined;
+  client_encoding?: string | undefined;
+}
+
+export type ConnectionConfig = ClientConfig;
+
+export interface Defaults extends ClientConfig {
+  poolSize?: number | undefined;
+  poolIdleTimeout?: number | undefined;
+  reapIntervalMillis?: number | undefined;
+  binary?: boolean | undefined;
+  parseInt8?: boolean | undefined;
+  parseInputDatesAsUTC?: boolean | undefined;
+}
+
+export interface PoolConfig extends ClientConfig {
+  max?: number | undefined;
+  min?: number | undefined;
+  idleTimeoutMillis?: number | undefined | null;
+  log?: ((...messages: any[]) => void) | undefined;
+  Promise?: PromiseConstructorLike | undefined;
+  allowExitOnIdle?: boolean | undefined;
+  maxUses?: number | undefined;
+  maxLifetimeSeconds?: number | undefined;
+  Client?: (new () => ClientBase) | undefined;
+}
+
+export interface CustomTypesConfig {
+  getTypeParser: (id: number, format?: string) => any;
+}
+
+// -- Message types ----------------------------------------------------------
+
+export interface FieldDef {
+  name: string;
+  tableID: number;
+  columnID: number;
+  dataTypeID: number;
+  dataTypeSize: number;
+  dataTypeModifier: number;
+  format: string;
+}
+
+export interface Notification {
+  processId: number;
+  channel: string;
+  payload?: string | undefined;
+}
+
+export interface BindConfig {
+  portal?: string | undefined;
+  statement?: string | undefined;
+  binary?: string | undefined;
+  values?: Array<Uint8Array | null | undefined | string> | undefined;
+  valueMapper?: ((param: any, index: number) => any) | undefined;
+}
+
+export interface ExecuteConfig {
+  portal?: string | undefined;
+  rows?: string | undefined;
+}
+
+export interface MessageConfig {
+  type: string;
+  name?: string | undefined;
+}
+
+export interface Submittable {
+  submit: (connection: Connection) => void;
+}
+
+// -- Classes ----------------------------------------------------------------
+
+export class Connection extends EventEmitter {
+  readonly stream: any;
+  constructor(config?: ConnectionConfig);
+  bind(config: BindConfig | null, more: boolean): void;
+  execute(config: ExecuteConfig | null, more: boolean): void;
+  parse(query: QueryParse, more: boolean): void;
+  query(text: string): void;
+  describe(msg: MessageConfig, more: boolean): void;
+  close(msg: MessageConfig, more: boolean): void;
+  flush(): void;
+  sync(): void;
+  end(): void;
+}
+
+export class ClientBase extends EventEmitter {
+  constructor(config?: string | ClientConfig);
+  connect(): Promise<void>;
+  connect(callback: (err: Error) => void): void;
+  query<T extends Submittable>(queryStream: T): T;
+  query<R extends any[] = any[], I = any[]>(
+    queryConfig: QueryArrayConfig<I>,
+    values?: QueryConfigValues<I>,
+  ): Promise<QueryArrayResult<R>>;
+  query<R extends QueryResultRow = any, I = any>(
+    queryConfig: QueryConfig<I>,
+  ): Promise<QueryResult<R>>;
+  query<R extends QueryResultRow = any, I = any[]>(
+    queryTextOrConfig: string | QueryConfig<I>,
+    values?: QueryConfigValues<I>,
+  ): Promise<QueryResult<R>>;
+  query<R extends any[] = any[], I = any[]>(
+    queryConfig: QueryArrayConfig<I>,
+    callback: (err: Error, result: QueryArrayResult<R>) => void,
+  ): void;
+  query<R extends QueryResultRow = any, I = any[]>(
+    queryTextOrConfig: string | QueryConfig<I>,
+    callback: (err: Error, result: QueryResult<R>) => void,
+  ): void;
+  query<R extends QueryResultRow = any, I = any[]>(
+    queryText: string,
+    values: QueryConfigValues<I>,
+    callback: (err: Error, result: QueryResult<R>) => void,
+  ): void;
+  pauseDrain(): void;
+  resumeDrain(): void;
+  escapeIdentifier(str: string): string;
+  escapeLiteral(str: string): string;
+  on(event: 'drain', listener: () => void): this;
+  on(event: 'error', listener: (err: Error) => void): this;
+  on(event: 'notification', listener: (message: Notification) => void): this;
+  on(event: 'end', listener: () => void): this;
+}
+
+export class Client extends ClientBase {
+  user?: string | undefined;
+  database?: string | undefined;
+  port: number;
+  host: string;
+  password?: string | undefined;
+  ssl: boolean;
+  readonly connection: Connection;
+  constructor(config?: string | ClientConfig);
+  end(): Promise<void>;
+  end(callback: (err: Error) => void): void;
+}
+
+export interface PoolClient extends ClientBase {
+  release(err?: Error | boolean): void;
+}
+
+export class Pool extends EventEmitter {
+  constructor(config?: PoolConfig);
+  options: PoolConfig;
+  readonly totalCount: number;
+  readonly idleCount: number;
+  readonly waitingCount: number;
+  readonly expiredCount: number;
+  readonly ending: boolean;
+  readonly ended: boolean;
+  connect(): Promise<PoolClient>;
+  connect(
+    callback: (
+      err: Error | undefined,
+      client: PoolClient | undefined,
+      done: (release?: any) => void,
+    ) => void,
+  ): void;
+  end(): Promise<void>;
+  end(callback: () => void): void;
+  query<T extends Submittable>(queryStream: T): T;
+  query<R extends any[] = any[], I = any[]>(
+    queryConfig: QueryArrayConfig<I>,
+    values?: QueryConfigValues<I>,
+  ): Promise<QueryArrayResult<R>>;
+  query<R extends QueryResultRow = any, I = any[]>(
+    queryConfig: QueryConfig<I>,
+  ): Promise<QueryResult<R>>;
+  query<R extends QueryResultRow = any, I = any[]>(
+    queryTextOrConfig: string | QueryConfig<I>,
+    values?: QueryConfigValues<I>,
+  ): Promise<QueryResult<R>>;
+  query<R extends any[] = any[], I = any[]>(
+    queryConfig: QueryArrayConfig<I>,
+    callback: (err: Error, result: QueryArrayResult<R>) => void,
+  ): void;
+  query<R extends QueryResultRow = any, I = any[]>(
+    queryTextOrConfig: string | QueryConfig<I>,
+    callback: (err: Error, result: QueryResult<R>) => void,
+  ): void;
+  query<R extends QueryResultRow = any, I = any[]>(
+    queryText: string,
+    values: QueryConfigValues<I>,
+    callback: (err: Error, result: QueryResult<R>) => void,
+  ): void;
+  on(
+    event: 'release' | 'error',
+    listener: (err: Error, client: PoolClient) => void,
+  ): this;
+  on(
+    event: 'connect' | 'acquire' | 'remove',
+    listener: (client: PoolClient) => void,
+  ): this;
+}
+
+export class Query<R extends QueryResultRow = any, I extends any[] = any>
+  extends EventEmitter
+  implements Submittable
+{
+  constructor(
+    queryTextOrConfig?: string | QueryConfig<I>,
+    values?: QueryConfigValues<I>,
+  );
+  submit: (connection: Connection) => void;
+  on(
+    event: 'row',
+    listener: (row: R, result?: ResultBuilder<R>) => void,
+  ): this;
+  on(event: 'error', listener: (err: Error) => void): this;
+  on(event: 'end', listener: (result: ResultBuilder<R>) => void): this;
+}
+
+export class Events extends EventEmitter {
+  on(event: 'error', listener: (err: Error, client: Client) => void): this;
+}
+
+export class DatabaseError extends Error {
+  readonly length: number;
+  readonly name: string;
+  severity: string | undefined;
+  code: string | undefined;
+  detail: string | undefined;
+  hint: string | undefined;
+  position: string | undefined;
+  internalPosition: string | undefined;
+  internalQuery: string | undefined;
+  where: string | undefined;
+  schema: string | undefined;
+  table: string | undefined;
+  column: string | undefined;
+  dataType: string | undefined;
+  constraint: string | undefined;
+  file: string | undefined;
+  line: string | undefined;
+  routine: string | undefined;
+  constructor(message: string, length: number, name: string);
+}
+
+// -- Value exports ----------------------------------------------------------
+
+export declare const types: {
+  setTypeParser(id: number, parseFn: (value: string) => any): void;
+  setTypeParser(
+    id: number,
+    format: 'text' | 'binary',
+    parseFn: (value: string) => any,
+  ): void;
+  getTypeParser(id: number, format?: 'text' | 'binary'): any;
+  arrayParser(source: string, transform: (entry: any) => any): any[];
+  builtins: { [key: string]: number };
+};
+
+export declare const defaults: Defaults & ClientConfig;
+
+export declare function escapeIdentifier(str: string): string;
+export declare function escapeLiteral(str: string): string;

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,6 +4,8 @@
 
 - The reason the serverless driver exists is to enable connecting (and connecting speedily) from a variety of platforms. We therefore test on a variety of platforms. The subfolders here contains these tests.
 
+- There are also tests for the compatibility of our pg type shims, in `type-compatibility.ts`. 
+
 ## Platforms
 
 ### `cli`

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,7 +4,7 @@
 
 - The reason the serverless driver exists is to enable connecting (and connecting speedily) from a variety of platforms. We therefore test on a variety of platforms. The subfolders here contains these tests.
 
-- There are also tests for the compatibility of our pg type shims, in `type-compatibility.ts`. 
+- There are also tests for the compatibility of our pg type shims, in `type-compatibility.ts`.
 
 ## Platforms
 

--- a/tests/type-compatibility.ts
+++ b/tests/type-compatibility.ts
@@ -13,13 +13,23 @@
  */
 
 import type * as Shims from '../src/shims/pg/index.d.ts';
-// Import the real @types/pg directly (bypass tsconfig paths)
+
+// import the real @types/pg directly (bypass tsconfig paths)
 import type * as Real from '../node_modules/@types/pg/index.d.ts';
 
-// Fails to compile if the real type has a property key that our shim lacks.
+// fails to compile if the real type has a property key that our shim lacks.
 type AssertKeys<_T extends true> = void;
 
-// Every key on Real.X must exist on Shims.X
+type AssertNever<_T extends never> = void;
+type MismatchedKeys<FromT, ToT> = {
+  [K in keyof FromT]-?: K extends keyof ToT
+    ? FromT[K] extends ToT[K]
+      ? never
+      : K
+    : K;
+}[keyof FromT];
+
+// every key on Real.X must exist on Shims.X
 type _ClientConfig = AssertKeys<keyof Real.ClientConfig extends keyof Shims.ClientConfig ? true : false>;
 type _ConnectionConfig = AssertKeys<keyof Real.ConnectionConfig extends keyof Shims.ConnectionConfig ? true : false>;
 type _Defaults = AssertKeys<keyof Real.Defaults extends keyof Shims.Defaults ? true : false>;
@@ -60,3 +70,30 @@ type _ExecuteConfig2 = AssertKeys<keyof Shims.ExecuteConfig extends keyof Real.E
 type _MessageConfig2 = AssertKeys<keyof Shims.MessageConfig extends keyof Real.MessageConfig ? true : false>;
 type _Notification2 = AssertKeys<keyof Shims.Notification extends keyof Real.Notification ? true : false>;
 type _Submittable2 = AssertKeys<keyof Shims.Submittable extends keyof Real.Submittable ? true : false>;
+
+// Usage compatibility checks:
+// - Inputs accepted by the library: Real -> Shim
+// - Outputs exposed by the library: Shim -> Real
+
+// Inputs (Real -> Shim), with key-level diagnostics in error output.
+type _ClientConfigInputCompat = AssertNever<MismatchedKeys<Real.ClientConfig, Shims.ClientConfig>>;
+type _ConnectionConfigInputCompat = AssertNever<MismatchedKeys<Real.ConnectionConfig, Shims.ConnectionConfig>>;
+type _DefaultsInputCompat = AssertNever<MismatchedKeys<Real.Defaults, Shims.Defaults>>;
+type _PoolConfigInputCompat = AssertNever<MismatchedKeys<Real.PoolConfig, Shims.PoolConfig>>;
+type _QueryConfigInputCompat = AssertNever<MismatchedKeys<Real.QueryConfig, Shims.QueryConfig>>;
+type _QueryArrayConfigInputCompat = AssertNever<MismatchedKeys<Real.QueryArrayConfig, Shims.QueryArrayConfig>>;
+type _CustomTypesConfigInputCompat = AssertNever<MismatchedKeys<Real.CustomTypesConfig, Shims.CustomTypesConfig>>;
+type _QueryParseInputCompat = AssertNever<MismatchedKeys<Real.QueryParse, Shims.QueryParse>>;
+type _BindConfigInputCompat = AssertNever<MismatchedKeys<Real.BindConfig, Shims.BindConfig>>;
+type _ExecuteConfigInputCompat = AssertNever<MismatchedKeys<Real.ExecuteConfig, Shims.ExecuteConfig>>;
+type _MessageConfigInputCompat = AssertNever<MismatchedKeys<Real.MessageConfig, Shims.MessageConfig>>;
+type _SubmittableInputCompat = AssertNever<MismatchedKeys<Real.Submittable, Shims.Submittable>>;
+
+// Outputs (Shim -> Real), with key-level diagnostics in error output.
+type _FieldDefOutputCompat = AssertNever<MismatchedKeys<Shims.FieldDef, Real.FieldDef>>;
+type _QueryResultBaseOutputCompat = AssertNever<MismatchedKeys<Shims.QueryResultBase, Real.QueryResultBase>>;
+type _QueryResultRowOutputCompat = AssertNever<MismatchedKeys<Shims.QueryResultRow, Real.QueryResultRow>>;
+type _QueryResultOutputCompat = AssertNever<MismatchedKeys<Shims.QueryResult, Real.QueryResult>>;
+type _QueryArrayResultOutputCompat = AssertNever<MismatchedKeys<Shims.QueryArrayResult, Real.QueryArrayResult>>;
+type _ResultBuilderOutputCompat = AssertNever<MismatchedKeys<Shims.ResultBuilder, Real.ResultBuilder>>;
+type _NotificationOutputCompat = AssertNever<MismatchedKeys<Shims.Notification, Real.Notification>>;

--- a/tests/type-compatibility.ts
+++ b/tests/type-compatibility.ts
@@ -560,9 +560,9 @@ type _SubmittableQueryReturnsInput = Assert<
 
 // negative checks to ensure invalid usage still fails
 
-// @ts-expect-error QueryArrayConfig rowMode must be "array"
 const _badRowMode: Shims.QueryArrayConfig = {
   text: 'select 1',
+  // @ts-expect-error QueryArrayConfig rowMode must be "array"
   rowMode: 'object',
 };
 // @ts-expect-error unknown PoolConfig property should not type-check

--- a/tests/type-compatibility.ts
+++ b/tests/type-compatibility.ts
@@ -21,54 +21,162 @@ import type * as Real from '../node_modules/@types/pg/index.d.ts';
 type Assert<_T extends true> = void;
 
 // every key on Real.X must exist on Shims.X
-type _ClientConfig = Assert<keyof Real.ClientConfig extends keyof Shims.ClientConfig ? true : false>;
-type _ConnectionConfig = Assert<keyof Real.ConnectionConfig extends keyof Shims.ConnectionConfig ? true : false>;
-type _Defaults = Assert<keyof Real.Defaults extends keyof Shims.Defaults ? true : false>;
-type _PoolConfig = Assert<keyof Real.PoolConfig extends keyof Shims.PoolConfig ? true : false>;
-type _QueryConfig = Assert<keyof Real.QueryConfig extends keyof Shims.QueryConfig ? true : false>;
-type _QueryArrayConfig = Assert<keyof Real.QueryArrayConfig extends keyof Shims.QueryArrayConfig ? true : false>;
-type _CustomTypesConfig = Assert<keyof Real.CustomTypesConfig extends keyof Shims.CustomTypesConfig ? true : false>;
-type _FieldDef = Assert<keyof Real.FieldDef extends keyof Shims.FieldDef ? true : false>;
-type _QueryResultBase = Assert<keyof Real.QueryResultBase extends keyof Shims.QueryResultBase ? true : false>;
-type _QueryResultRow = Assert<keyof Real.QueryResultRow extends keyof Shims.QueryResultRow ? true : false>;
-type _QueryResult = Assert<keyof Real.QueryResult extends keyof Shims.QueryResult ? true : false>;
-type _QueryArrayResult = Assert<keyof Real.QueryArrayResult extends keyof Shims.QueryArrayResult ? true : false>;
-type _ResultBuilder = Assert<keyof Real.ResultBuilder extends keyof Shims.ResultBuilder ? true : false>;
-type _QueryParse = Assert<keyof Real.QueryParse extends keyof Shims.QueryParse ? true : false>;
-type _BindConfig = Assert<keyof Real.BindConfig extends keyof Shims.BindConfig ? true : false>;
-type _ExecuteConfig = Assert<keyof Real.ExecuteConfig extends keyof Shims.ExecuteConfig ? true : false>;
-type _MessageConfig = Assert<keyof Real.MessageConfig extends keyof Shims.MessageConfig ? true : false>;
-type _Notification = Assert<keyof Real.Notification extends keyof Shims.Notification ? true : false>;
-type _Submittable = Assert<keyof Real.Submittable extends keyof Shims.Submittable ? true : false>;
-type _PoolOptions = Assert<keyof Real.PoolOptions extends keyof Shims.PoolOptions ? true : false>;
-type _Result = Assert<keyof Real.Result extends keyof Shims.Result ? true : false>;
-type _TypeOverrides = Assert<keyof Real.TypeOverrides extends keyof Shims.TypeOverrides ? true : false>;
-type _DatabaseError = Assert<keyof Real.DatabaseError extends keyof Shims.DatabaseError ? true : false>;
+type _ClientConfig = Assert<
+  keyof Real.ClientConfig extends keyof Shims.ClientConfig ? true : false
+>;
+type _ConnectionConfig = Assert<
+  keyof Real.ConnectionConfig extends keyof Shims.ConnectionConfig
+    ? true
+    : false
+>;
+type _Defaults = Assert<
+  keyof Real.Defaults extends keyof Shims.Defaults ? true : false
+>;
+type _PoolConfig = Assert<
+  keyof Real.PoolConfig extends keyof Shims.PoolConfig ? true : false
+>;
+type _QueryConfig = Assert<
+  keyof Real.QueryConfig extends keyof Shims.QueryConfig ? true : false
+>;
+type _QueryArrayConfig = Assert<
+  keyof Real.QueryArrayConfig extends keyof Shims.QueryArrayConfig
+    ? true
+    : false
+>;
+type _CustomTypesConfig = Assert<
+  keyof Real.CustomTypesConfig extends keyof Shims.CustomTypesConfig
+    ? true
+    : false
+>;
+type _FieldDef = Assert<
+  keyof Real.FieldDef extends keyof Shims.FieldDef ? true : false
+>;
+type _QueryResultBase = Assert<
+  keyof Real.QueryResultBase extends keyof Shims.QueryResultBase ? true : false
+>;
+type _QueryResultRow = Assert<
+  keyof Real.QueryResultRow extends keyof Shims.QueryResultRow ? true : false
+>;
+type _QueryResult = Assert<
+  keyof Real.QueryResult extends keyof Shims.QueryResult ? true : false
+>;
+type _QueryArrayResult = Assert<
+  keyof Real.QueryArrayResult extends keyof Shims.QueryArrayResult
+    ? true
+    : false
+>;
+type _ResultBuilder = Assert<
+  keyof Real.ResultBuilder extends keyof Shims.ResultBuilder ? true : false
+>;
+type _QueryParse = Assert<
+  keyof Real.QueryParse extends keyof Shims.QueryParse ? true : false
+>;
+type _BindConfig = Assert<
+  keyof Real.BindConfig extends keyof Shims.BindConfig ? true : false
+>;
+type _ExecuteConfig = Assert<
+  keyof Real.ExecuteConfig extends keyof Shims.ExecuteConfig ? true : false
+>;
+type _MessageConfig = Assert<
+  keyof Real.MessageConfig extends keyof Shims.MessageConfig ? true : false
+>;
+type _Notification = Assert<
+  keyof Real.Notification extends keyof Shims.Notification ? true : false
+>;
+type _Submittable = Assert<
+  keyof Real.Submittable extends keyof Shims.Submittable ? true : false
+>;
+type _PoolOptions = Assert<
+  keyof Real.PoolOptions extends keyof Shims.PoolOptions ? true : false
+>;
+type _Result = Assert<
+  keyof Real.Result extends keyof Shims.Result ? true : false
+>;
+type _TypeOverrides = Assert<
+  keyof Real.TypeOverrides extends keyof Shims.TypeOverrides ? true : false
+>;
+type _DatabaseError = Assert<
+  keyof Real.DatabaseError extends keyof Shims.DatabaseError ? true : false
+>;
 
 // and vice versa: our shim shouldn't have keys the real type doesn't
-type _ClientConfig2 = Assert<keyof Shims.ClientConfig extends keyof Real.ClientConfig ? true : false>;
-type _ConnectionConfig2 = Assert<keyof Shims.ConnectionConfig extends keyof Real.ConnectionConfig ? true : false>;
-type _Defaults2 = Assert<keyof Shims.Defaults extends keyof Real.Defaults ? true : false>;
-type _PoolConfig2 = Assert<keyof Shims.PoolConfig extends keyof Real.PoolConfig ? true : false>;
-type _QueryConfig2 = Assert<keyof Shims.QueryConfig extends keyof Real.QueryConfig ? true : false>;
-type _QueryArrayConfig2 = Assert<keyof Shims.QueryArrayConfig extends keyof Real.QueryArrayConfig ? true : false>;
-type _CustomTypesConfig2 = Assert<keyof Shims.CustomTypesConfig extends keyof Real.CustomTypesConfig ? true : false>;
-type _FieldDef2 = Assert<keyof Shims.FieldDef extends keyof Real.FieldDef ? true : false>;
-type _QueryResultBase2 = Assert<keyof Shims.QueryResultBase extends keyof Real.QueryResultBase ? true : false>;
-type _QueryResultRow2 = Assert<keyof Shims.QueryResultRow extends keyof Real.QueryResultRow ? true : false>;
-type _QueryResult2 = Assert<keyof Shims.QueryResult extends keyof Real.QueryResult ? true : false>;
-type _QueryArrayResult2 = Assert<keyof Shims.QueryArrayResult extends keyof Real.QueryArrayResult ? true : false>;
-type _ResultBuilder2 = Assert<keyof Shims.ResultBuilder extends keyof Real.ResultBuilder ? true : false>;
-type _QueryParse2 = Assert<keyof Shims.QueryParse extends keyof Real.QueryParse ? true : false>;
-type _BindConfig2 = Assert<keyof Shims.BindConfig extends keyof Real.BindConfig ? true : false>;
-type _ExecuteConfig2 = Assert<keyof Shims.ExecuteConfig extends keyof Real.ExecuteConfig ? true : false>;
-type _MessageConfig2 = Assert<keyof Shims.MessageConfig extends keyof Real.MessageConfig ? true : false>;
-type _Notification2 = Assert<keyof Shims.Notification extends keyof Real.Notification ? true : false>;
-type _Submittable2 = Assert<keyof Shims.Submittable extends keyof Real.Submittable ? true : false>;
-type _PoolOptions2 = Assert<keyof Shims.PoolOptions extends keyof Real.PoolOptions ? true : false>;
-type _Result2 = Assert<keyof Shims.Result extends keyof Real.Result ? true : false>;
-type _TypeOverrides2 = Assert<keyof Shims.TypeOverrides extends keyof Real.TypeOverrides ? true : false>;
-type _DatabaseError2 = Assert<keyof Shims.DatabaseError extends keyof Real.DatabaseError ? true : false>;
+type _ClientConfig2 = Assert<
+  keyof Shims.ClientConfig extends keyof Real.ClientConfig ? true : false
+>;
+type _ConnectionConfig2 = Assert<
+  keyof Shims.ConnectionConfig extends keyof Real.ConnectionConfig
+    ? true
+    : false
+>;
+type _Defaults2 = Assert<
+  keyof Shims.Defaults extends keyof Real.Defaults ? true : false
+>;
+type _PoolConfig2 = Assert<
+  keyof Shims.PoolConfig extends keyof Real.PoolConfig ? true : false
+>;
+type _QueryConfig2 = Assert<
+  keyof Shims.QueryConfig extends keyof Real.QueryConfig ? true : false
+>;
+type _QueryArrayConfig2 = Assert<
+  keyof Shims.QueryArrayConfig extends keyof Real.QueryArrayConfig
+    ? true
+    : false
+>;
+type _CustomTypesConfig2 = Assert<
+  keyof Shims.CustomTypesConfig extends keyof Real.CustomTypesConfig
+    ? true
+    : false
+>;
+type _FieldDef2 = Assert<
+  keyof Shims.FieldDef extends keyof Real.FieldDef ? true : false
+>;
+type _QueryResultBase2 = Assert<
+  keyof Shims.QueryResultBase extends keyof Real.QueryResultBase ? true : false
+>;
+type _QueryResultRow2 = Assert<
+  keyof Shims.QueryResultRow extends keyof Real.QueryResultRow ? true : false
+>;
+type _QueryResult2 = Assert<
+  keyof Shims.QueryResult extends keyof Real.QueryResult ? true : false
+>;
+type _QueryArrayResult2 = Assert<
+  keyof Shims.QueryArrayResult extends keyof Real.QueryArrayResult
+    ? true
+    : false
+>;
+type _ResultBuilder2 = Assert<
+  keyof Shims.ResultBuilder extends keyof Real.ResultBuilder ? true : false
+>;
+type _QueryParse2 = Assert<
+  keyof Shims.QueryParse extends keyof Real.QueryParse ? true : false
+>;
+type _BindConfig2 = Assert<
+  keyof Shims.BindConfig extends keyof Real.BindConfig ? true : false
+>;
+type _ExecuteConfig2 = Assert<
+  keyof Shims.ExecuteConfig extends keyof Real.ExecuteConfig ? true : false
+>;
+type _MessageConfig2 = Assert<
+  keyof Shims.MessageConfig extends keyof Real.MessageConfig ? true : false
+>;
+type _Notification2 = Assert<
+  keyof Shims.Notification extends keyof Real.Notification ? true : false
+>;
+type _Submittable2 = Assert<
+  keyof Shims.Submittable extends keyof Real.Submittable ? true : false
+>;
+type _PoolOptions2 = Assert<
+  keyof Shims.PoolOptions extends keyof Real.PoolOptions ? true : false
+>;
+type _Result2 = Assert<
+  keyof Shims.Result extends keyof Real.Result ? true : false
+>;
+type _TypeOverrides2 = Assert<
+  keyof Shims.TypeOverrides extends keyof Real.TypeOverrides ? true : false
+>;
+type _DatabaseError2 = Assert<
+  keyof Shims.DatabaseError extends keyof Real.DatabaseError ? true : false
+>;
 
 // Usage compatibility checks:
 // - inputs accepted by the library: Real -> Shim
@@ -85,75 +193,217 @@ type MismatchedKeys<FromT, ToT, IgnoreK extends PropertyKey = never> = {
 }[Exclude<keyof FromT, IgnoreK>];
 
 // inputs (Real -> Shim), with key-level diagnostics in error output
-type _ClientConfigInputCompat = AssertNever<MismatchedKeys<Real.ClientConfig, Shims.ClientConfig>>;
-type _ConnectionConfigInputCompat = AssertNever<MismatchedKeys<Real.ConnectionConfig, Shims.ConnectionConfig>>;
-type _DefaultsInputCompat = AssertNever<MismatchedKeys<Real.Defaults, Shims.Defaults>>;
-type _PoolConfigInputCompat = AssertNever<MismatchedKeys<Real.PoolConfig, Shims.PoolConfig>>;
-type _QueryConfigInputCompat = AssertNever<MismatchedKeys<Real.QueryConfig, Shims.QueryConfig>>;
-type _QueryArrayConfigInputCompat = AssertNever<MismatchedKeys<Real.QueryArrayConfig, Shims.QueryArrayConfig>>;
-type _CustomTypesConfigInputCompat = AssertNever<MismatchedKeys<Real.CustomTypesConfig, Shims.CustomTypesConfig>>;
-type _QueryParseInputCompat = AssertNever<MismatchedKeys<Real.QueryParse, Shims.QueryParse>>;
-type _BindConfigInputCompat = AssertNever<MismatchedKeys<Real.BindConfig, Shims.BindConfig>>;
-type _ExecuteConfigInputCompat = AssertNever<MismatchedKeys<Real.ExecuteConfig, Shims.ExecuteConfig>>;
-type _MessageConfigInputCompat = AssertNever<MismatchedKeys<Real.MessageConfig, Shims.MessageConfig>>;
-type _SubmittableInputCompat = AssertNever<MismatchedKeys<Real.Submittable, Shims.Submittable>>;
+type _ClientConfigInputCompat = AssertNever<
+  MismatchedKeys<Real.ClientConfig, Shims.ClientConfig>
+>;
+type _ConnectionConfigInputCompat = AssertNever<
+  MismatchedKeys<Real.ConnectionConfig, Shims.ConnectionConfig>
+>;
+type _DefaultsInputCompat = AssertNever<
+  MismatchedKeys<Real.Defaults, Shims.Defaults>
+>;
+type _PoolConfigInputCompat = AssertNever<
+  MismatchedKeys<Real.PoolConfig, Shims.PoolConfig>
+>;
+type _QueryConfigInputCompat = AssertNever<
+  MismatchedKeys<Real.QueryConfig, Shims.QueryConfig>
+>;
+type _QueryArrayConfigInputCompat = AssertNever<
+  MismatchedKeys<Real.QueryArrayConfig, Shims.QueryArrayConfig>
+>;
+type _CustomTypesConfigInputCompat = AssertNever<
+  MismatchedKeys<Real.CustomTypesConfig, Shims.CustomTypesConfig>
+>;
+type _QueryParseInputCompat = AssertNever<
+  MismatchedKeys<Real.QueryParse, Shims.QueryParse>
+>;
+type _BindConfigInputCompat = AssertNever<
+  MismatchedKeys<Real.BindConfig, Shims.BindConfig>
+>;
+type _ExecuteConfigInputCompat = AssertNever<
+  MismatchedKeys<Real.ExecuteConfig, Shims.ExecuteConfig>
+>;
+type _MessageConfigInputCompat = AssertNever<
+  MismatchedKeys<Real.MessageConfig, Shims.MessageConfig>
+>;
+type _SubmittableInputCompat = AssertNever<
+  MismatchedKeys<Real.Submittable, Shims.Submittable>
+>;
 
 // outputs (Shim -> Real), with key-level diagnostics in error output
-type _FieldDefOutputCompat = AssertNever<MismatchedKeys<Shims.FieldDef, Real.FieldDef>>;
-type _QueryResultBaseOutputCompat = AssertNever<MismatchedKeys<Shims.QueryResultBase, Real.QueryResultBase>>;
-type _QueryResultRowOutputCompat = AssertNever<MismatchedKeys<Shims.QueryResultRow, Real.QueryResultRow>>;
-type _QueryResultOutputCompat = AssertNever<MismatchedKeys<Shims.QueryResult, Real.QueryResult>>;
-type _QueryArrayResultOutputCompat = AssertNever<MismatchedKeys<Shims.QueryArrayResult, Real.QueryArrayResult>>;
-type _ResultBuilderOutputCompat = AssertNever<MismatchedKeys<Shims.ResultBuilder, Real.ResultBuilder>>;
-type _NotificationOutputCompat = AssertNever<MismatchedKeys<Shims.Notification, Real.Notification>>;
+type _FieldDefOutputCompat = AssertNever<
+  MismatchedKeys<Shims.FieldDef, Real.FieldDef>
+>;
+type _QueryResultBaseOutputCompat = AssertNever<
+  MismatchedKeys<Shims.QueryResultBase, Real.QueryResultBase>
+>;
+type _QueryResultRowOutputCompat = AssertNever<
+  MismatchedKeys<Shims.QueryResultRow, Real.QueryResultRow>
+>;
+type _QueryResultOutputCompat = AssertNever<
+  MismatchedKeys<Shims.QueryResult, Real.QueryResult>
+>;
+type _QueryArrayResultOutputCompat = AssertNever<
+  MismatchedKeys<Shims.QueryArrayResult, Real.QueryArrayResult>
+>;
+type _ResultBuilderOutputCompat = AssertNever<
+  MismatchedKeys<Shims.ResultBuilder, Real.ResultBuilder>
+>;
+type _NotificationOutputCompat = AssertNever<
+  MismatchedKeys<Shims.Notification, Real.Notification>
+>;
 
 // class + method compatibility checks --
 // constructors/statics (Real -> Shim): user code that instantiates/classes against
 // real types should still type-check against shims
-type _ConnectionCtorCompat = Assert<typeof Real.Connection extends typeof Shims.Connection ? true : false>;
-type _ClientBaseCtorCompat = Assert<typeof Real.ClientBase extends typeof Shims.ClientBase ? true : false>;
-type _ClientCtorCompat = Assert<typeof Real.Client extends typeof Shims.Client ? true : false>;
-type _PoolCtorCompat = Assert<typeof Real.Pool extends typeof Shims.Pool ? true : false>;
-type _QueryCtorCompat = Assert<typeof Real.Query extends typeof Shims.Query ? true : false>;
-type _EventsCtorCompat = Assert<typeof Real.Events extends typeof Shims.Events ? true : false>;
-type _ResultCtorCompat = Assert<typeof Real.Result extends typeof Shims.Result ? true : false>;
-type _TypeOverridesCtorCompat = Assert<typeof Real.TypeOverrides extends typeof Shims.TypeOverrides ? true : false>;
-type _DatabaseErrorCtorCompat = Assert<typeof Real.DatabaseError extends typeof Shims.DatabaseError ? true : false>;
+type _ConnectionCtorCompat = Assert<
+  typeof Real.Connection extends typeof Shims.Connection ? true : false
+>;
+type _ClientBaseCtorCompat = Assert<
+  typeof Real.ClientBase extends typeof Shims.ClientBase ? true : false
+>;
+type _ClientCtorCompat = Assert<
+  typeof Real.Client extends typeof Shims.Client ? true : false
+>;
+type _PoolCtorCompat = Assert<
+  typeof Real.Pool extends typeof Shims.Pool ? true : false
+>;
+type _QueryCtorCompat = Assert<
+  typeof Real.Query extends typeof Shims.Query ? true : false
+>;
+type _EventsCtorCompat = Assert<
+  typeof Real.Events extends typeof Shims.Events ? true : false
+>;
+type _ResultCtorCompat = Assert<
+  typeof Real.Result extends typeof Shims.Result ? true : false
+>;
+type _TypeOverridesCtorCompat = Assert<
+  typeof Real.TypeOverrides extends typeof Shims.TypeOverrides ? true : false
+>;
+type _DatabaseErrorCtorCompat = Assert<
+  typeof Real.DatabaseError extends typeof Shims.DatabaseError ? true : false
+>;
 
 // instance methods/properties: inputs use Real -> Shim and outputs use Shim -> Real
-type _ConnectionInputCompat = AssertNever<MismatchedKeys<Real.Connection, Shims.Connection>>;
-type _ClientBaseInputCompat = AssertNever<MismatchedKeys<Real.ClientBase, Shims.ClientBase, keyof import('events').EventEmitter>>;
-type _ClientInputCompat = AssertNever<MismatchedKeys<Real.Client, Shims.Client, keyof import('events').EventEmitter>>;
-type _PoolClientInputCompat = AssertNever<MismatchedKeys<Real.PoolClient, Shims.PoolClient, keyof import('events').EventEmitter>>;
-type _PoolInputCompat = AssertNever<MismatchedKeys<Real.Pool, Shims.Pool, keyof import('events').EventEmitter>>;
+type _ConnectionInputCompat = AssertNever<
+  MismatchedKeys<Real.Connection, Shims.Connection>
+>;
+type _ClientBaseInputCompat = AssertNever<
+  MismatchedKeys<
+    Real.ClientBase,
+    Shims.ClientBase,
+    keyof import('events').EventEmitter
+  >
+>;
+type _ClientInputCompat = AssertNever<
+  MismatchedKeys<Real.Client, Shims.Client, keyof import('events').EventEmitter>
+>;
+type _PoolClientInputCompat = AssertNever<
+  MismatchedKeys<
+    Real.PoolClient,
+    Shims.PoolClient,
+    keyof import('events').EventEmitter
+  >
+>;
+type _PoolInputCompat = AssertNever<
+  MismatchedKeys<Real.Pool, Shims.Pool, keyof import('events').EventEmitter>
+>;
 type _QueryInputCompat = AssertNever<MismatchedKeys<Real.Query, Shims.Query>>;
-type _EventsInputCompat = AssertNever<MismatchedKeys<Real.Events, Shims.Events, keyof import('events').EventEmitter>>;
-type _ConnectionOutputCompat = AssertNever<MismatchedKeys<Shims.Connection, Real.Connection>>;
+type _EventsInputCompat = AssertNever<
+  MismatchedKeys<Real.Events, Shims.Events, keyof import('events').EventEmitter>
+>;
+type _ConnectionOutputCompat = AssertNever<
+  MismatchedKeys<Shims.Connection, Real.Connection>
+>;
 
 type FunctionKeys<T> = {
-    [K in keyof T]-?: T[K] extends (...args: any[]) => any ? K : never;
-  }[keyof T];
+  [K in keyof T]-?: T[K] extends (...args: any[]) => any ? K : never;
+}[keyof T];
 
 // for class outputs, check data properties only (method variance can be noisy)
-type _ClientBaseOutputCompat = AssertNever<MismatchedKeys<Shims.ClientBase, Real.ClientBase, keyof import('events').EventEmitter | FunctionKeys<Shims.ClientBase>>>;
-type _ClientOutputCompat = AssertNever<MismatchedKeys<Shims.Client, Real.Client, keyof import('events').EventEmitter | FunctionKeys<Shims.Client>>>;
-type _PoolClientOutputCompat = AssertNever<MismatchedKeys<Shims.PoolClient, Real.PoolClient, keyof import('events').EventEmitter | FunctionKeys<Shims.PoolClient>>>;
-type _PoolOutputCompat = AssertNever<MismatchedKeys<Shims.Pool, Real.Pool, keyof import('events').EventEmitter | FunctionKeys<Shims.Pool>>>;
-type _QueryOutputCompat = AssertNever<MismatchedKeys<Shims.Query, Real.Query, FunctionKeys<Shims.Query>>>;
-type _EventsOutputCompat = AssertNever<MismatchedKeys<Shims.Events, Real.Events, keyof import('events').EventEmitter | FunctionKeys<Shims.Events>>>;
-type _ResultInputCompat = AssertNever<MismatchedKeys<Real.Result, Shims.Result, FunctionKeys<Real.Result>>>;
-type _ResultOutputCompat = AssertNever<MismatchedKeys<Shims.Result, Real.Result, FunctionKeys<Shims.Result>>>;
-type _TypeOverridesInputCompat = AssertNever<MismatchedKeys<Real.TypeOverrides, Shims.TypeOverrides, FunctionKeys<Real.TypeOverrides>>>;
-type _TypeOverridesOutputCompat = AssertNever<MismatchedKeys<Shims.TypeOverrides, Real.TypeOverrides, FunctionKeys<Shims.TypeOverrides>>>;
-type _DatabaseErrorInputCompat = AssertNever<MismatchedKeys<Real.DatabaseError, Shims.DatabaseError, keyof Error>>;
-type _DatabaseErrorOutputCompat = AssertNever<MismatchedKeys<Shims.DatabaseError, Real.DatabaseError, keyof Error>>;
+type _ClientBaseOutputCompat = AssertNever<
+  MismatchedKeys<
+    Shims.ClientBase,
+    Real.ClientBase,
+    keyof import('events').EventEmitter | FunctionKeys<Shims.ClientBase>
+  >
+>;
+type _ClientOutputCompat = AssertNever<
+  MismatchedKeys<
+    Shims.Client,
+    Real.Client,
+    keyof import('events').EventEmitter | FunctionKeys<Shims.Client>
+  >
+>;
+type _PoolClientOutputCompat = AssertNever<
+  MismatchedKeys<
+    Shims.PoolClient,
+    Real.PoolClient,
+    keyof import('events').EventEmitter | FunctionKeys<Shims.PoolClient>
+  >
+>;
+type _PoolOutputCompat = AssertNever<
+  MismatchedKeys<
+    Shims.Pool,
+    Real.Pool,
+    keyof import('events').EventEmitter | FunctionKeys<Shims.Pool>
+  >
+>;
+type _QueryOutputCompat = AssertNever<
+  MismatchedKeys<Shims.Query, Real.Query, FunctionKeys<Shims.Query>>
+>;
+type _EventsOutputCompat = AssertNever<
+  MismatchedKeys<
+    Shims.Events,
+    Real.Events,
+    keyof import('events').EventEmitter | FunctionKeys<Shims.Events>
+  >
+>;
+type _ResultInputCompat = AssertNever<
+  MismatchedKeys<Real.Result, Shims.Result, FunctionKeys<Real.Result>>
+>;
+type _ResultOutputCompat = AssertNever<
+  MismatchedKeys<Shims.Result, Real.Result, FunctionKeys<Shims.Result>>
+>;
+type _TypeOverridesInputCompat = AssertNever<
+  MismatchedKeys<
+    Real.TypeOverrides,
+    Shims.TypeOverrides,
+    FunctionKeys<Real.TypeOverrides>
+  >
+>;
+type _TypeOverridesOutputCompat = AssertNever<
+  MismatchedKeys<
+    Shims.TypeOverrides,
+    Real.TypeOverrides,
+    FunctionKeys<Shims.TypeOverrides>
+  >
+>;
+type _DatabaseErrorInputCompat = AssertNever<
+  MismatchedKeys<Real.DatabaseError, Shims.DatabaseError, keyof Error>
+>;
+type _DatabaseErrorOutputCompat = AssertNever<
+  MismatchedKeys<Shims.DatabaseError, Real.DatabaseError, keyof Error>
+>;
 
 // value exports compatibility: Real -> Shim (consumers using real types should work with shims)
-type _TypesExportCompat = Assert<typeof Real.types extends typeof Shims.types ? true : false>;
-type _DefaultsExportCompat = Assert<typeof Real.defaults extends typeof Shims.defaults ? true : false>;
-type _EscapeIdentifierExportCompat = Assert<typeof Real.escapeIdentifier extends typeof Shims.escapeIdentifier ? true : false>;
-type _EscapeLiteralExportCompat = Assert<typeof Real.escapeLiteral extends typeof Shims.escapeLiteral ? true : false>;
-type _NativeExportCompat = Assert<typeof Real.native extends typeof Shims.native ? true : false>;
+type _TypesExportCompat = Assert<
+  typeof Real.types extends typeof Shims.types ? true : false
+>;
+type _DefaultsExportCompat = Assert<
+  typeof Real.defaults extends typeof Shims.defaults ? true : false
+>;
+type _EscapeIdentifierExportCompat = Assert<
+  typeof Real.escapeIdentifier extends typeof Shims.escapeIdentifier
+    ? true
+    : false
+>;
+type _EscapeLiteralExportCompat = Assert<
+  typeof Real.escapeLiteral extends typeof Shims.escapeLiteral ? true : false
+>;
+type _NativeExportCompat = Assert<
+  typeof Real.native extends typeof Shims.native ? true : false
+>;
 
 // real-world usage contract checks (compile-time only):
 // these mimic common app patterns to catch practical type regressions
@@ -204,20 +454,26 @@ const _clientConfigStreamFactory: Shims.ClientConfig = {
 const _shimPoolConnectPromise = _shimPool.connect();
 const _realPoolConnectPromise = _realPool.connect();
 type _PoolConnectReturnsPoolClient = Assert<
-  Awaited<typeof _shimPoolConnectPromise> extends Shims.PoolClient ? true : false
+  Awaited<typeof _shimPoolConnectPromise> extends Shims.PoolClient
+    ? true
+    : false
 >;
 type _RealPoolConnectAcceptedByShim = Assert<
-  Awaited<typeof _realPoolConnectPromise> extends Shims.PoolClient ? true : false
+  Awaited<typeof _realPoolConnectPromise> extends Shims.PoolClient
+    ? true
+    : false
 >;
 type _PoolClientHasRelease = Assert<
-  Shims.PoolClient['release'] extends (err?: Error | boolean) => void ? true : false
+  Shims.PoolClient['release'] extends (err?: Error | boolean) => void
+    ? true
+    : false
 >;
 const _clientBaseFromPoolClient: Shims.ClientBase = _shimPoolClient;
 
 // generic query return typing
 
 const _poolQueryResultPromise = _shimPool.query<AppRow>(
-  'select 1 as id, \'neon\' as name',
+  "select 1 as id, 'neon' as name",
 );
 type _PoolQueryRowsPreserveGeneric = Assert<
   Awaited<typeof _poolQueryResultPromise>['rows'][number] extends AppRow
@@ -225,7 +481,7 @@ type _PoolQueryRowsPreserveGeneric = Assert<
     : false
 >;
 const _clientQueryResultPromise = _shimClient.query<AppRow>(
-  'select 1 as id, \'neon\' as name',
+  "select 1 as id, 'neon' as name",
 );
 type _ClientQueryRowsPreserveGeneric = Assert<
   Awaited<typeof _clientQueryResultPromise>['rows'][number] extends AppRow
@@ -233,11 +489,14 @@ type _ClientQueryRowsPreserveGeneric = Assert<
     : false
 >;
 const _poolArrayQueryResultPromise = _shimPool.query<[number, string]>({
-  text: 'select 1, \'neon\'',
+  text: "select 1, 'neon'",
   rowMode: 'array',
 });
 type _PoolArrayQueryRowsPreserveTuple = Assert<
-  Awaited<typeof _poolArrayQueryResultPromise>['rows'][number] extends [number, string]
+  Awaited<typeof _poolArrayQueryResultPromise>['rows'][number] extends [
+    number,
+    string,
+  ]
     ? true
     : false
 >;
@@ -302,10 +561,12 @@ type _SubmittableQueryReturnsInput = Assert<
 // negative checks to ensure invalid usage still fails
 
 // @ts-expect-error QueryArrayConfig rowMode must be "array"
-const _badRowMode: Shims.QueryArrayConfig = { text: 'select 1', rowMode: 'object' };
+const _badRowMode: Shims.QueryArrayConfig = {
+  text: 'select 1',
+  rowMode: 'object',
+};
 // @ts-expect-error unknown PoolConfig property should not type-check
 const _badPoolConfig: Shims.PoolConfig = { max: 1, doesNotExist: true };
-
 
 // consumer checks for drizzle and Prisma
 
@@ -323,7 +584,8 @@ interface DrizzleNodePgPoolLike extends DrizzleNodePgClientLike {
 }
 
 const _drizzleClientLikeFromShimClient: DrizzleNodePgClientLike = _shimClient;
-const _drizzleClientLikeFromShimPoolClient: DrizzleNodePgClientLike = _shimPoolClient;
+const _drizzleClientLikeFromShimPoolClient: DrizzleNodePgClientLike =
+  _shimPoolClient;
 const _drizzlePoolLikeFromShimPool: DrizzleNodePgPoolLike = _shimPool;
 
 // node-postgres compatibility nuance: many consumers rely on the "notice" event
@@ -351,7 +613,9 @@ const _shimPoolConfigForPrisma: Shims.PoolConfig = {
 const _prismaNeonFromShimConfig = new PrismaNeon(_shimPoolConfigForPrisma);
 
 type _PrismaNeonCtorAcceptsShimPoolConfig = Assert<
-  Shims.PoolConfig extends ConstructorParameters<typeof PrismaNeon>[0] ? true : false
+  Shims.PoolConfig extends ConstructorParameters<typeof PrismaNeon>[0]
+    ? true
+    : false
 >;
 
 void _drizzleClientLikeFromShimClient;

--- a/tests/type-compatibility.ts
+++ b/tests/type-compatibility.ts
@@ -40,8 +40,12 @@ type _ExecuteConfig = Assert<keyof Real.ExecuteConfig extends keyof Shims.Execut
 type _MessageConfig = Assert<keyof Real.MessageConfig extends keyof Shims.MessageConfig ? true : false>;
 type _Notification = Assert<keyof Real.Notification extends keyof Shims.Notification ? true : false>;
 type _Submittable = Assert<keyof Real.Submittable extends keyof Shims.Submittable ? true : false>;
+type _PoolOptions = Assert<keyof Real.PoolOptions extends keyof Shims.PoolOptions ? true : false>;
+type _Result = Assert<keyof Real.Result extends keyof Shims.Result ? true : false>;
+type _TypeOverrides = Assert<keyof Real.TypeOverrides extends keyof Shims.TypeOverrides ? true : false>;
+type _DatabaseError = Assert<keyof Real.DatabaseError extends keyof Shims.DatabaseError ? true : false>;
 
-// And vice versa: our shim shouldn't have keys the real type doesn't
+// and vice versa: our shim shouldn't have keys the real type doesn't
 type _ClientConfig2 = Assert<keyof Shims.ClientConfig extends keyof Real.ClientConfig ? true : false>;
 type _ConnectionConfig2 = Assert<keyof Shims.ConnectionConfig extends keyof Real.ConnectionConfig ? true : false>;
 type _Defaults2 = Assert<keyof Shims.Defaults extends keyof Real.Defaults ? true : false>;
@@ -61,6 +65,10 @@ type _ExecuteConfig2 = Assert<keyof Shims.ExecuteConfig extends keyof Real.Execu
 type _MessageConfig2 = Assert<keyof Shims.MessageConfig extends keyof Real.MessageConfig ? true : false>;
 type _Notification2 = Assert<keyof Shims.Notification extends keyof Real.Notification ? true : false>;
 type _Submittable2 = Assert<keyof Shims.Submittable extends keyof Real.Submittable ? true : false>;
+type _PoolOptions2 = Assert<keyof Shims.PoolOptions extends keyof Real.PoolOptions ? true : false>;
+type _Result2 = Assert<keyof Shims.Result extends keyof Real.Result ? true : false>;
+type _TypeOverrides2 = Assert<keyof Shims.TypeOverrides extends keyof Real.TypeOverrides ? true : false>;
+type _DatabaseError2 = Assert<keyof Shims.DatabaseError extends keyof Real.DatabaseError ? true : false>;
 
 // Usage compatibility checks:
 // - inputs accepted by the library: Real -> Shim
@@ -75,7 +83,6 @@ type MismatchedKeys<FromT, ToT, IgnoreK extends PropertyKey = never> = {
       : K
     : K;
 }[Exclude<keyof FromT, IgnoreK>];
-
 
 // inputs (Real -> Shim), with key-level diagnostics in error output
 type _ClientConfigInputCompat = AssertNever<MismatchedKeys<Real.ClientConfig, Shims.ClientConfig>>;
@@ -109,6 +116,9 @@ type _ClientCtorCompat = Assert<typeof Real.Client extends typeof Shims.Client ?
 type _PoolCtorCompat = Assert<typeof Real.Pool extends typeof Shims.Pool ? true : false>;
 type _QueryCtorCompat = Assert<typeof Real.Query extends typeof Shims.Query ? true : false>;
 type _EventsCtorCompat = Assert<typeof Real.Events extends typeof Shims.Events ? true : false>;
+type _ResultCtorCompat = Assert<typeof Real.Result extends typeof Shims.Result ? true : false>;
+type _TypeOverridesCtorCompat = Assert<typeof Real.TypeOverrides extends typeof Shims.TypeOverrides ? true : false>;
+type _DatabaseErrorCtorCompat = Assert<typeof Real.DatabaseError extends typeof Shims.DatabaseError ? true : false>;
 
 // instance methods/properties: inputs use Real -> Shim and outputs use Shim -> Real
 type _ConnectionInputCompat = AssertNever<MismatchedKeys<Real.Connection, Shims.Connection>>;
@@ -131,9 +141,22 @@ type _PoolClientOutputCompat = AssertNever<MismatchedKeys<Shims.PoolClient, Real
 type _PoolOutputCompat = AssertNever<MismatchedKeys<Shims.Pool, Real.Pool, keyof import('events').EventEmitter | FunctionKeys<Shims.Pool>>>;
 type _QueryOutputCompat = AssertNever<MismatchedKeys<Shims.Query, Real.Query, FunctionKeys<Shims.Query>>>;
 type _EventsOutputCompat = AssertNever<MismatchedKeys<Shims.Events, Real.Events, keyof import('events').EventEmitter | FunctionKeys<Shims.Events>>>;
+type _ResultInputCompat = AssertNever<MismatchedKeys<Real.Result, Shims.Result, FunctionKeys<Real.Result>>>;
+type _ResultOutputCompat = AssertNever<MismatchedKeys<Shims.Result, Real.Result, FunctionKeys<Shims.Result>>>;
+type _TypeOverridesInputCompat = AssertNever<MismatchedKeys<Real.TypeOverrides, Shims.TypeOverrides, FunctionKeys<Real.TypeOverrides>>>;
+type _TypeOverridesOutputCompat = AssertNever<MismatchedKeys<Shims.TypeOverrides, Real.TypeOverrides, FunctionKeys<Shims.TypeOverrides>>>;
+type _DatabaseErrorInputCompat = AssertNever<MismatchedKeys<Real.DatabaseError, Shims.DatabaseError, keyof Error>>;
+type _DatabaseErrorOutputCompat = AssertNever<MismatchedKeys<Shims.DatabaseError, Real.DatabaseError, keyof Error>>;
 
-// Real-world usage contract checks (compile-time only)
-// These mimic common app patterns to catch practical type regressions.
+// value exports compatibility: Real -> Shim (consumers using real types should work with shims)
+type _TypesExportCompat = Assert<typeof Real.types extends typeof Shims.types ? true : false>;
+type _DefaultsExportCompat = Assert<typeof Real.defaults extends typeof Shims.defaults ? true : false>;
+type _EscapeIdentifierExportCompat = Assert<typeof Real.escapeIdentifier extends typeof Shims.escapeIdentifier ? true : false>;
+type _EscapeLiteralExportCompat = Assert<typeof Real.escapeLiteral extends typeof Shims.escapeLiteral ? true : false>;
+type _NativeExportCompat = Assert<typeof Real.native extends typeof Shims.native ? true : false>;
+
+// real-world usage contract checks (compile-time only):
+// these mimic common app patterns to catch practical type regressions
 
 type AppRow = { id: number; name: string };
 
@@ -146,6 +169,7 @@ declare const _shimFieldDef: Shims.FieldDef;
 declare const _realPool: Real.Pool;
 
 // config compatibility: minimal + commonly used options
+
 const _poolConfigMinimal: Shims.PoolConfig = {
   connectionString: 'postgres://user:pass@localhost:5432/db',
 };
@@ -176,6 +200,7 @@ const _clientConfigStreamFactory: Shims.ClientConfig = {
 };
 
 // connect() contract and PoolClient release()
+
 const _shimPoolConnectPromise = _shimPool.connect();
 const _realPoolConnectPromise = _realPool.connect();
 type _PoolConnectReturnsPoolClient = Assert<
@@ -190,6 +215,7 @@ type _PoolClientHasRelease = Assert<
 const _clientBaseFromPoolClient: Shims.ClientBase = _shimPoolClient;
 
 // generic query return typing
+
 const _poolQueryResultPromise = _shimPool.query<AppRow>(
   'select 1 as id, \'neon\' as name',
 );
@@ -217,6 +243,7 @@ type _PoolArrayQueryRowsPreserveTuple = Assert<
 >;
 
 // prepared statement/query config usage
+
 const _queryConfigWithValues: Shims.QueryConfig<[number, string]> = {
   name: 'get-user-by-id',
   text: 'select * from users where id = $1 and org = $2',
@@ -229,6 +256,7 @@ const _queryArrayConfig: Shims.QueryArrayConfig<[number]> = {
 };
 
 // query output shape used by app code
+
 const _rows: AppRow[] = _shimQueryResult.rows;
 const _rowCount: number | null = _shimQueryResult.rowCount;
 const _command: string = _shimQueryResult.command;
@@ -237,6 +265,7 @@ const _fieldName: string = _shimFieldDef.name;
 const _fieldDataTypeId: number = _shimFieldDef.dataTypeID;
 
 // event callback usage patterns
+
 _shimClientBase.on('notification', (message) => {
   const _channel: string = message.channel;
   const _processId: number = message.processId;
@@ -260,7 +289,8 @@ _shimPool.on('error', (err, client) => {
   client.release();
 });
 
-// Submittable passthrough support in query APIs
+// submittable passthrough support in query APIs
+
 const _submittable: Shims.Submittable = {
   submit(_connection: Shims.Connection) {},
 };
@@ -270,6 +300,7 @@ type _SubmittableQueryReturnsInput = Assert<
 >;
 
 // negative checks to ensure invalid usage still fails
+
 // @ts-expect-error QueryArrayConfig rowMode must be "array"
 const _badRowMode: Shims.QueryArrayConfig = { text: 'select 1', rowMode: 'object' };
 // @ts-expect-error unknown PoolConfig property should not type-check
@@ -280,8 +311,9 @@ const _badPoolConfig: Shims.PoolConfig = { max: 1, doesNotExist: true };
 
 import { PrismaNeon } from '@prisma/adapter-neon';
 
-// Drizzle-style node-postgres contract subset.
-// We keep this focused on the pieces Drizzle commonly relies on in practice.
+// drizzle-style node-postgres contract subset --
+// we keep this focused on the pieces Drizzle commonly relies on in practice
+
 interface DrizzleNodePgClientLike {
   query: Shims.ClientBase['query'];
 }
@@ -294,7 +326,8 @@ const _drizzleClientLikeFromShimClient: DrizzleNodePgClientLike = _shimClient;
 const _drizzleClientLikeFromShimPoolClient: DrizzleNodePgClientLike = _shimPoolClient;
 const _drizzlePoolLikeFromShimPool: DrizzleNodePgPoolLike = _shimPool;
 
-// node-postgres compatibility nuance: many consumers rely on the "notice" event.
+// node-postgres compatibility nuance: many consumers rely on the "notice" event
+
 interface PgNoticeEventLike {
   on(event: 'notice', listener: (notice: Shims.NoticeMessage) => void): unknown;
 }
@@ -308,7 +341,8 @@ type _ShimPoolSupportsDrizzleLikeConnect = Assert<
   Shims.Pool['connect'] extends DrizzleNodePgPoolLike['connect'] ? true : false
 >;
 
-// Prisma Neon adapter should accept pg-like pool config from shims.
+// Prisma Neon adapter should accept pg-like pool config from shims
+
 const _shimPoolConfigForPrisma: Shims.PoolConfig = {
   connectionString: 'postgres://user:pass@localhost:5432/db',
   ssl: { rejectUnauthorized: true },

--- a/tests/type-compatibility.ts
+++ b/tests/type-compatibility.ts
@@ -21,13 +21,17 @@ import type * as Real from '../node_modules/@types/pg/index.d.ts';
 type AssertKeys<_T extends true> = void;
 
 type AssertNever<_T extends never> = void;
-type MismatchedKeys<FromT, ToT> = {
-  [K in keyof FromT]-?: K extends keyof ToT
-    ? FromT[K] extends ToT[K]
+
+type FunctionKeys<T> = {
+  [K in keyof T]-?: T[K] extends (...args: any[]) => any ? K : never;
+}[keyof T];
+type MismatchedKeys<FromT, ToT, IgnoreK extends PropertyKey = never> = {
+  [K in Exclude<keyof FromT, IgnoreK>]-?: K extends keyof ToT
+    ? [FromT[K]] extends [ToT[K]]
       ? never
       : K
     : K;
-}[keyof FromT];
+}[Exclude<keyof FromT, IgnoreK>];
 
 // every key on Real.X must exist on Shims.X
 type _ClientConfig = AssertKeys<keyof Real.ClientConfig extends keyof Shims.ClientConfig ? true : false>;
@@ -72,10 +76,10 @@ type _Notification2 = AssertKeys<keyof Shims.Notification extends keyof Real.Not
 type _Submittable2 = AssertKeys<keyof Shims.Submittable extends keyof Real.Submittable ? true : false>;
 
 // Usage compatibility checks:
-// - Inputs accepted by the library: Real -> Shim
-// - Outputs exposed by the library: Shim -> Real
+// - inputs accepted by the library: Real -> Shim
+// - outputs exposed by the library: Shim -> Real
 
-// Inputs (Real -> Shim), with key-level diagnostics in error output.
+// inputs (Real -> Shim), with key-level diagnostics in error output
 type _ClientConfigInputCompat = AssertNever<MismatchedKeys<Real.ClientConfig, Shims.ClientConfig>>;
 type _ConnectionConfigInputCompat = AssertNever<MismatchedKeys<Real.ConnectionConfig, Shims.ConnectionConfig>>;
 type _DefaultsInputCompat = AssertNever<MismatchedKeys<Real.Defaults, Shims.Defaults>>;
@@ -89,7 +93,7 @@ type _ExecuteConfigInputCompat = AssertNever<MismatchedKeys<Real.ExecuteConfig, 
 type _MessageConfigInputCompat = AssertNever<MismatchedKeys<Real.MessageConfig, Shims.MessageConfig>>;
 type _SubmittableInputCompat = AssertNever<MismatchedKeys<Real.Submittable, Shims.Submittable>>;
 
-// Outputs (Shim -> Real), with key-level diagnostics in error output.
+// outputs (Shim -> Real), with key-level diagnostics in error output
 type _FieldDefOutputCompat = AssertNever<MismatchedKeys<Shims.FieldDef, Real.FieldDef>>;
 type _QueryResultBaseOutputCompat = AssertNever<MismatchedKeys<Shims.QueryResultBase, Real.QueryResultBase>>;
 type _QueryResultRowOutputCompat = AssertNever<MismatchedKeys<Shims.QueryResultRow, Real.QueryResultRow>>;
@@ -97,3 +101,31 @@ type _QueryResultOutputCompat = AssertNever<MismatchedKeys<Shims.QueryResult, Re
 type _QueryArrayResultOutputCompat = AssertNever<MismatchedKeys<Shims.QueryArrayResult, Real.QueryArrayResult>>;
 type _ResultBuilderOutputCompat = AssertNever<MismatchedKeys<Shims.ResultBuilder, Real.ResultBuilder>>;
 type _NotificationOutputCompat = AssertNever<MismatchedKeys<Shims.Notification, Real.Notification>>;
+
+// class + method compatibility checks --
+// constructors/statics (Real -> Shim): user code that instantiates/classes against
+// real types should still type-check against shims
+type _ConnectionCtorCompat = AssertKeys<typeof Real.Connection extends typeof Shims.Connection ? true : false>;
+type _ClientBaseCtorCompat = AssertKeys<typeof Real.ClientBase extends typeof Shims.ClientBase ? true : false>;
+type _ClientCtorCompat = AssertKeys<typeof Real.Client extends typeof Shims.Client ? true : false>;
+type _PoolCtorCompat = AssertKeys<typeof Real.Pool extends typeof Shims.Pool ? true : false>;
+type _QueryCtorCompat = AssertKeys<typeof Real.Query extends typeof Shims.Query ? true : false>;
+type _EventsCtorCompat = AssertKeys<typeof Real.Events extends typeof Shims.Events ? true : false>;
+
+// instance methods/properties: inputs use Real -> Shim and outputs use Shim -> Real
+type _ConnectionInputCompat = AssertNever<MismatchedKeys<Real.Connection, Shims.Connection>>;
+type _ClientBaseInputCompat = AssertNever<MismatchedKeys<Real.ClientBase, Shims.ClientBase, keyof import('events').EventEmitter>>;
+type _ClientInputCompat = AssertNever<MismatchedKeys<Real.Client, Shims.Client, keyof import('events').EventEmitter>>;
+type _PoolClientInputCompat = AssertNever<MismatchedKeys<Real.PoolClient, Shims.PoolClient, keyof import('events').EventEmitter>>;
+type _PoolInputCompat = AssertNever<MismatchedKeys<Real.Pool, Shims.Pool, keyof import('events').EventEmitter>>;
+type _QueryInputCompat = AssertNever<MismatchedKeys<Real.Query, Shims.Query>>;
+type _EventsInputCompat = AssertNever<MismatchedKeys<Real.Events, Shims.Events, keyof import('events').EventEmitter>>;
+type _ConnectionOutputCompat = AssertNever<MismatchedKeys<Shims.Connection, Real.Connection>>;
+
+// for class outputs, check data properties only (method variance can be noisy)
+type _ClientBaseOutputCompat = AssertNever<MismatchedKeys<Shims.ClientBase, Real.ClientBase, keyof import('events').EventEmitter | FunctionKeys<Shims.ClientBase>>>;
+type _ClientOutputCompat = AssertNever<MismatchedKeys<Shims.Client, Real.Client, keyof import('events').EventEmitter | FunctionKeys<Shims.Client>>>;
+type _PoolClientOutputCompat = AssertNever<MismatchedKeys<Shims.PoolClient, Real.PoolClient, keyof import('events').EventEmitter | FunctionKeys<Shims.PoolClient>>>;
+type _PoolOutputCompat = AssertNever<MismatchedKeys<Shims.Pool, Real.Pool, keyof import('events').EventEmitter | FunctionKeys<Shims.Pool>>>;
+type _QueryOutputCompat = AssertNever<MismatchedKeys<Shims.Query, Real.Query, FunctionKeys<Shims.Query>>>;
+type _EventsOutputCompat = AssertNever<MismatchedKeys<Shims.Events, Real.Events, keyof import('events').EventEmitter | FunctionKeys<Shims.Events>>>;

--- a/tests/type-compatibility.ts
+++ b/tests/type-compatibility.ts
@@ -18,49 +18,49 @@ import type * as Shims from '../src/shims/pg/index.d.ts';
 import type * as Real from '../node_modules/@types/pg/index.d.ts';
 
 // fails to compile if the real type has a property key that our shim lacks.
-type AssertKeys<_T extends true> = void;
+type Assert<_T extends true> = void;
 
 // every key on Real.X must exist on Shims.X
-type _ClientConfig = AssertKeys<keyof Real.ClientConfig extends keyof Shims.ClientConfig ? true : false>;
-type _ConnectionConfig = AssertKeys<keyof Real.ConnectionConfig extends keyof Shims.ConnectionConfig ? true : false>;
-type _Defaults = AssertKeys<keyof Real.Defaults extends keyof Shims.Defaults ? true : false>;
-type _PoolConfig = AssertKeys<keyof Real.PoolConfig extends keyof Shims.PoolConfig ? true : false>;
-type _QueryConfig = AssertKeys<keyof Real.QueryConfig extends keyof Shims.QueryConfig ? true : false>;
-type _QueryArrayConfig = AssertKeys<keyof Real.QueryArrayConfig extends keyof Shims.QueryArrayConfig ? true : false>;
-type _CustomTypesConfig = AssertKeys<keyof Real.CustomTypesConfig extends keyof Shims.CustomTypesConfig ? true : false>;
-type _FieldDef = AssertKeys<keyof Real.FieldDef extends keyof Shims.FieldDef ? true : false>;
-type _QueryResultBase = AssertKeys<keyof Real.QueryResultBase extends keyof Shims.QueryResultBase ? true : false>;
-type _QueryResultRow = AssertKeys<keyof Real.QueryResultRow extends keyof Shims.QueryResultRow ? true : false>;
-type _QueryResult = AssertKeys<keyof Real.QueryResult extends keyof Shims.QueryResult ? true : false>;
-type _QueryArrayResult = AssertKeys<keyof Real.QueryArrayResult extends keyof Shims.QueryArrayResult ? true : false>;
-type _ResultBuilder = AssertKeys<keyof Real.ResultBuilder extends keyof Shims.ResultBuilder ? true : false>;
-type _QueryParse = AssertKeys<keyof Real.QueryParse extends keyof Shims.QueryParse ? true : false>;
-type _BindConfig = AssertKeys<keyof Real.BindConfig extends keyof Shims.BindConfig ? true : false>;
-type _ExecuteConfig = AssertKeys<keyof Real.ExecuteConfig extends keyof Shims.ExecuteConfig ? true : false>;
-type _MessageConfig = AssertKeys<keyof Real.MessageConfig extends keyof Shims.MessageConfig ? true : false>;
-type _Notification = AssertKeys<keyof Real.Notification extends keyof Shims.Notification ? true : false>;
-type _Submittable = AssertKeys<keyof Real.Submittable extends keyof Shims.Submittable ? true : false>;
+type _ClientConfig = Assert<keyof Real.ClientConfig extends keyof Shims.ClientConfig ? true : false>;
+type _ConnectionConfig = Assert<keyof Real.ConnectionConfig extends keyof Shims.ConnectionConfig ? true : false>;
+type _Defaults = Assert<keyof Real.Defaults extends keyof Shims.Defaults ? true : false>;
+type _PoolConfig = Assert<keyof Real.PoolConfig extends keyof Shims.PoolConfig ? true : false>;
+type _QueryConfig = Assert<keyof Real.QueryConfig extends keyof Shims.QueryConfig ? true : false>;
+type _QueryArrayConfig = Assert<keyof Real.QueryArrayConfig extends keyof Shims.QueryArrayConfig ? true : false>;
+type _CustomTypesConfig = Assert<keyof Real.CustomTypesConfig extends keyof Shims.CustomTypesConfig ? true : false>;
+type _FieldDef = Assert<keyof Real.FieldDef extends keyof Shims.FieldDef ? true : false>;
+type _QueryResultBase = Assert<keyof Real.QueryResultBase extends keyof Shims.QueryResultBase ? true : false>;
+type _QueryResultRow = Assert<keyof Real.QueryResultRow extends keyof Shims.QueryResultRow ? true : false>;
+type _QueryResult = Assert<keyof Real.QueryResult extends keyof Shims.QueryResult ? true : false>;
+type _QueryArrayResult = Assert<keyof Real.QueryArrayResult extends keyof Shims.QueryArrayResult ? true : false>;
+type _ResultBuilder = Assert<keyof Real.ResultBuilder extends keyof Shims.ResultBuilder ? true : false>;
+type _QueryParse = Assert<keyof Real.QueryParse extends keyof Shims.QueryParse ? true : false>;
+type _BindConfig = Assert<keyof Real.BindConfig extends keyof Shims.BindConfig ? true : false>;
+type _ExecuteConfig = Assert<keyof Real.ExecuteConfig extends keyof Shims.ExecuteConfig ? true : false>;
+type _MessageConfig = Assert<keyof Real.MessageConfig extends keyof Shims.MessageConfig ? true : false>;
+type _Notification = Assert<keyof Real.Notification extends keyof Shims.Notification ? true : false>;
+type _Submittable = Assert<keyof Real.Submittable extends keyof Shims.Submittable ? true : false>;
 
 // And vice versa: our shim shouldn't have keys the real type doesn't
-type _ClientConfig2 = AssertKeys<keyof Shims.ClientConfig extends keyof Real.ClientConfig ? true : false>;
-type _ConnectionConfig2 = AssertKeys<keyof Shims.ConnectionConfig extends keyof Real.ConnectionConfig ? true : false>;
-type _Defaults2 = AssertKeys<keyof Shims.Defaults extends keyof Real.Defaults ? true : false>;
-type _PoolConfig2 = AssertKeys<keyof Shims.PoolConfig extends keyof Real.PoolConfig ? true : false>;
-type _QueryConfig2 = AssertKeys<keyof Shims.QueryConfig extends keyof Real.QueryConfig ? true : false>;
-type _QueryArrayConfig2 = AssertKeys<keyof Shims.QueryArrayConfig extends keyof Real.QueryArrayConfig ? true : false>;
-type _CustomTypesConfig2 = AssertKeys<keyof Shims.CustomTypesConfig extends keyof Real.CustomTypesConfig ? true : false>;
-type _FieldDef2 = AssertKeys<keyof Shims.FieldDef extends keyof Real.FieldDef ? true : false>;
-type _QueryResultBase2 = AssertKeys<keyof Shims.QueryResultBase extends keyof Real.QueryResultBase ? true : false>;
-type _QueryResultRow2 = AssertKeys<keyof Shims.QueryResultRow extends keyof Real.QueryResultRow ? true : false>;
-type _QueryResult2 = AssertKeys<keyof Shims.QueryResult extends keyof Real.QueryResult ? true : false>;
-type _QueryArrayResult2 = AssertKeys<keyof Shims.QueryArrayResult extends keyof Real.QueryArrayResult ? true : false>;
-type _ResultBuilder2 = AssertKeys<keyof Shims.ResultBuilder extends keyof Real.ResultBuilder ? true : false>;
-type _QueryParse2 = AssertKeys<keyof Shims.QueryParse extends keyof Real.QueryParse ? true : false>;
-type _BindConfig2 = AssertKeys<keyof Shims.BindConfig extends keyof Real.BindConfig ? true : false>;
-type _ExecuteConfig2 = AssertKeys<keyof Shims.ExecuteConfig extends keyof Real.ExecuteConfig ? true : false>;
-type _MessageConfig2 = AssertKeys<keyof Shims.MessageConfig extends keyof Real.MessageConfig ? true : false>;
-type _Notification2 = AssertKeys<keyof Shims.Notification extends keyof Real.Notification ? true : false>;
-type _Submittable2 = AssertKeys<keyof Shims.Submittable extends keyof Real.Submittable ? true : false>;
+type _ClientConfig2 = Assert<keyof Shims.ClientConfig extends keyof Real.ClientConfig ? true : false>;
+type _ConnectionConfig2 = Assert<keyof Shims.ConnectionConfig extends keyof Real.ConnectionConfig ? true : false>;
+type _Defaults2 = Assert<keyof Shims.Defaults extends keyof Real.Defaults ? true : false>;
+type _PoolConfig2 = Assert<keyof Shims.PoolConfig extends keyof Real.PoolConfig ? true : false>;
+type _QueryConfig2 = Assert<keyof Shims.QueryConfig extends keyof Real.QueryConfig ? true : false>;
+type _QueryArrayConfig2 = Assert<keyof Shims.QueryArrayConfig extends keyof Real.QueryArrayConfig ? true : false>;
+type _CustomTypesConfig2 = Assert<keyof Shims.CustomTypesConfig extends keyof Real.CustomTypesConfig ? true : false>;
+type _FieldDef2 = Assert<keyof Shims.FieldDef extends keyof Real.FieldDef ? true : false>;
+type _QueryResultBase2 = Assert<keyof Shims.QueryResultBase extends keyof Real.QueryResultBase ? true : false>;
+type _QueryResultRow2 = Assert<keyof Shims.QueryResultRow extends keyof Real.QueryResultRow ? true : false>;
+type _QueryResult2 = Assert<keyof Shims.QueryResult extends keyof Real.QueryResult ? true : false>;
+type _QueryArrayResult2 = Assert<keyof Shims.QueryArrayResult extends keyof Real.QueryArrayResult ? true : false>;
+type _ResultBuilder2 = Assert<keyof Shims.ResultBuilder extends keyof Real.ResultBuilder ? true : false>;
+type _QueryParse2 = Assert<keyof Shims.QueryParse extends keyof Real.QueryParse ? true : false>;
+type _BindConfig2 = Assert<keyof Shims.BindConfig extends keyof Real.BindConfig ? true : false>;
+type _ExecuteConfig2 = Assert<keyof Shims.ExecuteConfig extends keyof Real.ExecuteConfig ? true : false>;
+type _MessageConfig2 = Assert<keyof Shims.MessageConfig extends keyof Real.MessageConfig ? true : false>;
+type _Notification2 = Assert<keyof Shims.Notification extends keyof Real.Notification ? true : false>;
+type _Submittable2 = Assert<keyof Shims.Submittable extends keyof Real.Submittable ? true : false>;
 
 // Usage compatibility checks:
 // - inputs accepted by the library: Real -> Shim
@@ -103,12 +103,12 @@ type _NotificationOutputCompat = AssertNever<MismatchedKeys<Shims.Notification, 
 // class + method compatibility checks --
 // constructors/statics (Real -> Shim): user code that instantiates/classes against
 // real types should still type-check against shims
-type _ConnectionCtorCompat = AssertKeys<typeof Real.Connection extends typeof Shims.Connection ? true : false>;
-type _ClientBaseCtorCompat = AssertKeys<typeof Real.ClientBase extends typeof Shims.ClientBase ? true : false>;
-type _ClientCtorCompat = AssertKeys<typeof Real.Client extends typeof Shims.Client ? true : false>;
-type _PoolCtorCompat = AssertKeys<typeof Real.Pool extends typeof Shims.Pool ? true : false>;
-type _QueryCtorCompat = AssertKeys<typeof Real.Query extends typeof Shims.Query ? true : false>;
-type _EventsCtorCompat = AssertKeys<typeof Real.Events extends typeof Shims.Events ? true : false>;
+type _ConnectionCtorCompat = Assert<typeof Real.Connection extends typeof Shims.Connection ? true : false>;
+type _ClientBaseCtorCompat = Assert<typeof Real.ClientBase extends typeof Shims.ClientBase ? true : false>;
+type _ClientCtorCompat = Assert<typeof Real.Client extends typeof Shims.Client ? true : false>;
+type _PoolCtorCompat = Assert<typeof Real.Pool extends typeof Shims.Pool ? true : false>;
+type _QueryCtorCompat = Assert<typeof Real.Query extends typeof Shims.Query ? true : false>;
+type _EventsCtorCompat = Assert<typeof Real.Events extends typeof Shims.Events ? true : false>;
 
 // instance methods/properties: inputs use Real -> Shim and outputs use Shim -> Real
 type _ConnectionInputCompat = AssertNever<MismatchedKeys<Real.Connection, Shims.Connection>>;
@@ -131,3 +131,196 @@ type _PoolClientOutputCompat = AssertNever<MismatchedKeys<Shims.PoolClient, Real
 type _PoolOutputCompat = AssertNever<MismatchedKeys<Shims.Pool, Real.Pool, keyof import('events').EventEmitter | FunctionKeys<Shims.Pool>>>;
 type _QueryOutputCompat = AssertNever<MismatchedKeys<Shims.Query, Real.Query, FunctionKeys<Shims.Query>>>;
 type _EventsOutputCompat = AssertNever<MismatchedKeys<Shims.Events, Real.Events, keyof import('events').EventEmitter | FunctionKeys<Shims.Events>>>;
+
+// Real-world usage contract checks (compile-time only)
+// These mimic common app patterns to catch practical type regressions.
+
+type AppRow = { id: number; name: string };
+
+declare const _shimPool: Shims.Pool;
+declare const _shimClient: Shims.Client;
+declare const _shimClientBase: Shims.ClientBase;
+declare const _shimPoolClient: Shims.PoolClient;
+declare const _shimQueryResult: Shims.QueryResult<AppRow>;
+declare const _shimFieldDef: Shims.FieldDef;
+declare const _realPool: Real.Pool;
+
+// config compatibility: minimal + commonly used options
+const _poolConfigMinimal: Shims.PoolConfig = {
+  connectionString: 'postgres://user:pass@localhost:5432/db',
+};
+const _poolConfigFull: Shims.PoolConfig = {
+  connectionString: 'postgres://user:pass@localhost:5432/db',
+  ssl: { rejectUnauthorized: true },
+  max: 10,
+  idleTimeoutMillis: 5_000,
+  allowExitOnIdle: true,
+};
+const _clientConfigHostPort: Shims.ClientConfig = {
+  host: 'localhost',
+  port: 5432,
+  ssl: false,
+};
+const _clientConfigConnectionString: Shims.ClientConfig = {
+  connectionString: 'postgres://user:pass@localhost:5432/db',
+};
+const _clientConfigCustomTypes: Shims.ClientConfig = {
+  types: {
+    getTypeParser(id, format) {
+      return () => `${id}:${format ?? 'text'}`;
+    },
+  },
+};
+const _clientConfigStreamFactory: Shims.ClientConfig = {
+  stream: () => undefined,
+};
+
+// connect() contract and PoolClient release()
+const _shimPoolConnectPromise = _shimPool.connect();
+const _realPoolConnectPromise = _realPool.connect();
+type _PoolConnectReturnsPoolClient = Assert<
+  Awaited<typeof _shimPoolConnectPromise> extends Shims.PoolClient ? true : false
+>;
+type _RealPoolConnectAcceptedByShim = Assert<
+  Awaited<typeof _realPoolConnectPromise> extends Shims.PoolClient ? true : false
+>;
+type _PoolClientHasRelease = Assert<
+  Shims.PoolClient['release'] extends (err?: Error | boolean) => void ? true : false
+>;
+const _clientBaseFromPoolClient: Shims.ClientBase = _shimPoolClient;
+
+// generic query return typing
+const _poolQueryResultPromise = _shimPool.query<AppRow>(
+  'select 1 as id, \'neon\' as name',
+);
+type _PoolQueryRowsPreserveGeneric = Assert<
+  Awaited<typeof _poolQueryResultPromise>['rows'][number] extends AppRow
+    ? true
+    : false
+>;
+const _clientQueryResultPromise = _shimClient.query<AppRow>(
+  'select 1 as id, \'neon\' as name',
+);
+type _ClientQueryRowsPreserveGeneric = Assert<
+  Awaited<typeof _clientQueryResultPromise>['rows'][number] extends AppRow
+    ? true
+    : false
+>;
+const _poolArrayQueryResultPromise = _shimPool.query<[number, string]>({
+  text: 'select 1, \'neon\'',
+  rowMode: 'array',
+});
+type _PoolArrayQueryRowsPreserveTuple = Assert<
+  Awaited<typeof _poolArrayQueryResultPromise>['rows'][number] extends [number, string]
+    ? true
+    : false
+>;
+
+// prepared statement/query config usage
+const _queryConfigWithValues: Shims.QueryConfig<[number, string]> = {
+  name: 'get-user-by-id',
+  text: 'select * from users where id = $1 and org = $2',
+  values: [123, 'org_1'],
+};
+const _queryArrayConfig: Shims.QueryArrayConfig<[number]> = {
+  text: 'select $1',
+  values: [123],
+  rowMode: 'array',
+};
+
+// query output shape used by app code
+const _rows: AppRow[] = _shimQueryResult.rows;
+const _rowCount: number | null = _shimQueryResult.rowCount;
+const _command: string = _shimQueryResult.command;
+const _fields: Shims.FieldDef[] = _shimQueryResult.fields;
+const _fieldName: string = _shimFieldDef.name;
+const _fieldDataTypeId: number = _shimFieldDef.dataTypeID;
+
+// event callback usage patterns
+_shimClientBase.on('notification', (message) => {
+  const _channel: string = message.channel;
+  const _processId: number = message.processId;
+  const _payload: string | undefined = message.payload;
+});
+_shimClientBase.on('error', (err) => {
+  const _error: Error = err;
+});
+_shimClientBase.on('end', () => {});
+_shimPool.on('connect', (client) => {
+  client.release();
+});
+_shimPool.on('acquire', (client) => {
+  client.release();
+});
+_shimPool.on('remove', (client) => {
+  client.release();
+});
+_shimPool.on('error', (err, client) => {
+  const _error: Error = err;
+  client.release();
+});
+
+// Submittable passthrough support in query APIs
+const _submittable: Shims.Submittable = {
+  submit(_connection: Shims.Connection) {},
+};
+const _submittableResult = _shimPool.query(_submittable);
+type _SubmittableQueryReturnsInput = Assert<
+  typeof _submittableResult extends Shims.Submittable ? true : false
+>;
+
+// negative checks to ensure invalid usage still fails
+// @ts-expect-error QueryArrayConfig rowMode must be "array"
+const _badRowMode: Shims.QueryArrayConfig = { text: 'select 1', rowMode: 'object' };
+// @ts-expect-error unknown PoolConfig property should not type-check
+const _badPoolConfig: Shims.PoolConfig = { max: 1, doesNotExist: true };
+
+
+// consumer checks for drizzle and Prisma
+
+import { PrismaNeon } from '@prisma/adapter-neon';
+
+// Drizzle-style node-postgres contract subset.
+// We keep this focused on the pieces Drizzle commonly relies on in practice.
+interface DrizzleNodePgClientLike {
+  query: Shims.ClientBase['query'];
+}
+interface DrizzleNodePgPoolLike extends DrizzleNodePgClientLike {
+  connect: Shims.Pool['connect'];
+  end: Shims.Pool['end'];
+}
+
+const _drizzleClientLikeFromShimClient: DrizzleNodePgClientLike = _shimClient;
+const _drizzleClientLikeFromShimPoolClient: DrizzleNodePgClientLike = _shimPoolClient;
+const _drizzlePoolLikeFromShimPool: DrizzleNodePgPoolLike = _shimPool;
+
+// node-postgres compatibility nuance: many consumers rely on the "notice" event.
+interface PgNoticeEventLike {
+  on(event: 'notice', listener: (notice: Shims.NoticeMessage) => void): unknown;
+}
+const _noticeEventFromShimClient: PgNoticeEventLike = _shimClient;
+const _noticeEventFromShimPoolClient: PgNoticeEventLike = _shimPoolClient;
+
+type _ShimClientSupportsDrizzleLikeQuery = Assert<
+  Shims.Client['query'] extends DrizzleNodePgClientLike['query'] ? true : false
+>;
+type _ShimPoolSupportsDrizzleLikeConnect = Assert<
+  Shims.Pool['connect'] extends DrizzleNodePgPoolLike['connect'] ? true : false
+>;
+
+// Prisma Neon adapter should accept pg-like pool config from shims.
+const _shimPoolConfigForPrisma: Shims.PoolConfig = {
+  connectionString: 'postgres://user:pass@localhost:5432/db',
+  ssl: { rejectUnauthorized: true },
+  max: 10,
+};
+const _prismaNeonFromShimConfig = new PrismaNeon(_shimPoolConfigForPrisma);
+
+type _PrismaNeonCtorAcceptsShimPoolConfig = Assert<
+  Shims.PoolConfig extends ConstructorParameters<typeof PrismaNeon>[0] ? true : false
+>;
+
+void _drizzleClientLikeFromShimClient;
+void _drizzleClientLikeFromShimPoolClient;
+void _drizzlePoolLikeFromShimPool;
+void _prismaNeonFromShimConfig;

--- a/tests/type-compatibility.ts
+++ b/tests/type-compatibility.ts
@@ -20,19 +20,6 @@ import type * as Real from '../node_modules/@types/pg/index.d.ts';
 // fails to compile if the real type has a property key that our shim lacks.
 type AssertKeys<_T extends true> = void;
 
-type AssertNever<_T extends never> = void;
-
-type FunctionKeys<T> = {
-  [K in keyof T]-?: T[K] extends (...args: any[]) => any ? K : never;
-}[keyof T];
-type MismatchedKeys<FromT, ToT, IgnoreK extends PropertyKey = never> = {
-  [K in Exclude<keyof FromT, IgnoreK>]-?: K extends keyof ToT
-    ? [FromT[K]] extends [ToT[K]]
-      ? never
-      : K
-    : K;
-}[Exclude<keyof FromT, IgnoreK>];
-
 // every key on Real.X must exist on Shims.X
 type _ClientConfig = AssertKeys<keyof Real.ClientConfig extends keyof Shims.ClientConfig ? true : false>;
 type _ConnectionConfig = AssertKeys<keyof Real.ConnectionConfig extends keyof Shims.ConnectionConfig ? true : false>;
@@ -79,6 +66,17 @@ type _Submittable2 = AssertKeys<keyof Shims.Submittable extends keyof Real.Submi
 // - inputs accepted by the library: Real -> Shim
 // - outputs exposed by the library: Shim -> Real
 
+type AssertNever<_T extends never> = void;
+
+type MismatchedKeys<FromT, ToT, IgnoreK extends PropertyKey = never> = {
+  [K in Exclude<keyof FromT, IgnoreK>]-?: K extends keyof ToT
+    ? [FromT[K]] extends [ToT[K]]
+      ? never
+      : K
+    : K;
+}[Exclude<keyof FromT, IgnoreK>];
+
+
 // inputs (Real -> Shim), with key-level diagnostics in error output
 type _ClientConfigInputCompat = AssertNever<MismatchedKeys<Real.ClientConfig, Shims.ClientConfig>>;
 type _ConnectionConfigInputCompat = AssertNever<MismatchedKeys<Real.ConnectionConfig, Shims.ConnectionConfig>>;
@@ -121,6 +119,10 @@ type _PoolInputCompat = AssertNever<MismatchedKeys<Real.Pool, Shims.Pool, keyof 
 type _QueryInputCompat = AssertNever<MismatchedKeys<Real.Query, Shims.Query>>;
 type _EventsInputCompat = AssertNever<MismatchedKeys<Real.Events, Shims.Events, keyof import('events').EventEmitter>>;
 type _ConnectionOutputCompat = AssertNever<MismatchedKeys<Shims.Connection, Real.Connection>>;
+
+type FunctionKeys<T> = {
+    [K in keyof T]-?: T[K] extends (...args: any[]) => any ? K : never;
+  }[keyof T];
 
 // for class outputs, check data properties only (method variance can be noisy)
 type _ClientBaseOutputCompat = AssertNever<MismatchedKeys<Shims.ClientBase, Real.ClientBase, keyof import('events').EventEmitter | FunctionKeys<Shims.ClientBase>>>;

--- a/tests/type-compatibility.ts
+++ b/tests/type-compatibility.ts
@@ -1,0 +1,62 @@
+/**
+ * Type compatibility test.
+ *
+ * Verifies that our local pg shims declare all the same property keys
+ * as the real @types/pg types. If @types/pg adds a new required property
+ * to any interface, this test will fail to compile.
+ *
+ * We check keyof rather than structural assignability because our shims
+ * intentionally widen some types (e.g. `number` instead of `TypeId`,
+ * `Uint8Array` instead of `Buffer`, `object` instead of `ConnectionOptions`).
+ *
+ * Run: npm run test:type-shims
+ */
+
+import type * as Shims from '../src/shims/pg/index.d.ts';
+// Import the real @types/pg directly (bypass tsconfig paths)
+import type * as Real from '../node_modules/@types/pg/index.d.ts';
+
+// Fails to compile if the real type has a property key that our shim lacks.
+type AssertKeys<_T extends true> = void;
+
+// Every key on Real.X must exist on Shims.X
+type _ClientConfig = AssertKeys<keyof Real.ClientConfig extends keyof Shims.ClientConfig ? true : false>;
+type _ConnectionConfig = AssertKeys<keyof Real.ConnectionConfig extends keyof Shims.ConnectionConfig ? true : false>;
+type _Defaults = AssertKeys<keyof Real.Defaults extends keyof Shims.Defaults ? true : false>;
+type _PoolConfig = AssertKeys<keyof Real.PoolConfig extends keyof Shims.PoolConfig ? true : false>;
+type _QueryConfig = AssertKeys<keyof Real.QueryConfig extends keyof Shims.QueryConfig ? true : false>;
+type _QueryArrayConfig = AssertKeys<keyof Real.QueryArrayConfig extends keyof Shims.QueryArrayConfig ? true : false>;
+type _CustomTypesConfig = AssertKeys<keyof Real.CustomTypesConfig extends keyof Shims.CustomTypesConfig ? true : false>;
+type _FieldDef = AssertKeys<keyof Real.FieldDef extends keyof Shims.FieldDef ? true : false>;
+type _QueryResultBase = AssertKeys<keyof Real.QueryResultBase extends keyof Shims.QueryResultBase ? true : false>;
+type _QueryResultRow = AssertKeys<keyof Real.QueryResultRow extends keyof Shims.QueryResultRow ? true : false>;
+type _QueryResult = AssertKeys<keyof Real.QueryResult extends keyof Shims.QueryResult ? true : false>;
+type _QueryArrayResult = AssertKeys<keyof Real.QueryArrayResult extends keyof Shims.QueryArrayResult ? true : false>;
+type _ResultBuilder = AssertKeys<keyof Real.ResultBuilder extends keyof Shims.ResultBuilder ? true : false>;
+type _QueryParse = AssertKeys<keyof Real.QueryParse extends keyof Shims.QueryParse ? true : false>;
+type _BindConfig = AssertKeys<keyof Real.BindConfig extends keyof Shims.BindConfig ? true : false>;
+type _ExecuteConfig = AssertKeys<keyof Real.ExecuteConfig extends keyof Shims.ExecuteConfig ? true : false>;
+type _MessageConfig = AssertKeys<keyof Real.MessageConfig extends keyof Shims.MessageConfig ? true : false>;
+type _Notification = AssertKeys<keyof Real.Notification extends keyof Shims.Notification ? true : false>;
+type _Submittable = AssertKeys<keyof Real.Submittable extends keyof Shims.Submittable ? true : false>;
+
+// And vice versa: our shim shouldn't have keys the real type doesn't
+type _ClientConfig2 = AssertKeys<keyof Shims.ClientConfig extends keyof Real.ClientConfig ? true : false>;
+type _ConnectionConfig2 = AssertKeys<keyof Shims.ConnectionConfig extends keyof Real.ConnectionConfig ? true : false>;
+type _Defaults2 = AssertKeys<keyof Shims.Defaults extends keyof Real.Defaults ? true : false>;
+type _PoolConfig2 = AssertKeys<keyof Shims.PoolConfig extends keyof Real.PoolConfig ? true : false>;
+type _QueryConfig2 = AssertKeys<keyof Shims.QueryConfig extends keyof Real.QueryConfig ? true : false>;
+type _QueryArrayConfig2 = AssertKeys<keyof Shims.QueryArrayConfig extends keyof Real.QueryArrayConfig ? true : false>;
+type _CustomTypesConfig2 = AssertKeys<keyof Shims.CustomTypesConfig extends keyof Real.CustomTypesConfig ? true : false>;
+type _FieldDef2 = AssertKeys<keyof Shims.FieldDef extends keyof Real.FieldDef ? true : false>;
+type _QueryResultBase2 = AssertKeys<keyof Shims.QueryResultBase extends keyof Real.QueryResultBase ? true : false>;
+type _QueryResultRow2 = AssertKeys<keyof Shims.QueryResultRow extends keyof Real.QueryResultRow ? true : false>;
+type _QueryResult2 = AssertKeys<keyof Shims.QueryResult extends keyof Real.QueryResult ? true : false>;
+type _QueryArrayResult2 = AssertKeys<keyof Shims.QueryArrayResult extends keyof Real.QueryArrayResult ? true : false>;
+type _ResultBuilder2 = AssertKeys<keyof Shims.ResultBuilder extends keyof Real.ResultBuilder ? true : false>;
+type _QueryParse2 = AssertKeys<keyof Shims.QueryParse extends keyof Real.QueryParse ? true : false>;
+type _BindConfig2 = AssertKeys<keyof Shims.BindConfig extends keyof Real.BindConfig ? true : false>;
+type _ExecuteConfig2 = AssertKeys<keyof Shims.ExecuteConfig extends keyof Real.ExecuteConfig ? true : false>;
+type _MessageConfig2 = AssertKeys<keyof Shims.MessageConfig extends keyof Real.MessageConfig ? true : false>;
+type _Notification2 = AssertKeys<keyof Shims.Notification extends keyof Real.Notification ? true : false>;
+type _Submittable2 = AssertKeys<keyof Shims.Submittable extends keyof Real.Submittable ? true : false>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,10 @@
     ] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
     "module": "ES2022" /* Specify what module code is generated. */,
     "moduleResolution": "Node" /* Specify how TypeScript looks up a file from a given module specifier. */,
+    "paths": {
+      "pg": ["./src/shims/pg"],
+      "events": ["./src/shims/events"]
+    },
     "esModuleInterop": true,
     "resolveJsonModule": true /* Enable importing .json files */,
     "allowJs": true /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */,


### PR DESCRIPTION
This PR builds on https://github.com/neondatabase/serverless/pull/194 from Netlify, including an updated suite of new type-compatibility tests.

Per the updated `CHANGELOG.md`:

> Type declarations are now fully inlined (some were previously re-exported from `@types/pg` and `@types/node`). The new types greatly reduce the size of the package with dependencies, and should be compatible in normal usage. The code that is actually run remains unchanged.
>
> A few advanced type-level patterns could be affected. Code that depends on exact type identity with the `@types/pg` exports, that relies on `declare module 'pg'` augmentation flowing through these exports, or that assumes `Buffer`-specific types in places now declared as `Uint8Array` may need updated types.

This is currently proposed as a minor version update rather than a patch, since incompatibilities with the previous version are expected to be very rare but not impossible. We could alternatively do a major version increment, but I think that would raise expectations of much larger changes.