### PR TITLE
Update release scripts and instructions and add type shims maintenance guidance

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -24,4 +24,4 @@ npm install @neondatabase/serverless@github:neondatabase/serverless#BRANCH_OR_CO
 
 ## Publish on npm and JSR
 
-Tests must be passing locally, you must be on branch `main`, the repo must be clean, and `CHANGELOG.md` must include notes for the new version. Then simply run `npm version` with `patch`, `minor` or `major`.
+Tests must be passing locally, the repo must be clean, and `CHANGELOG.md` must include notes for the new version. Then run `npm version $BUMP --ignore-scripts=false` where `$BUMP` is `patch`, `minor` or `major`.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "scripts": {
     "build": "./build.sh",
-    "preversion": "([[ $(git branch --show-current) = 'main' ]] || echo 'Must be on `main`') && git pull && npm run format && npm run test",
+    "preversion": "git pull && npm run format && npm run test",
     "version": "(grep $npm_package_version CHANGELOG.md || 'Update CHANGELOG.md') && git checkout -b release/v$npm_package_version && jq --arg v $npm_package_version '.version = $v' jsr.json > build/jsr.json && mv build/jsr.json jsr.json && git add jsr.json index.js index.d.ts index.mjs index.d.mts",
     "postversion": "git push --follow-tags origin release/v$npm_package_version && echo 'Release $npm_package_version created. Run `npm publish` and `npx jsr publish` once PR is merged into `main`.'",
     "format": "prettier -c .",

--- a/src/shims/pg/index.d.ts
+++ b/src/shims/pg/index.d.ts
@@ -4,6 +4,23 @@
  *
  * esbuild ignores tsconfig paths, so the real `pg` module from node_modules
  * is still used for the runtime bundle.
+ *
+ * == Maintaining this shim ==
+ *
+ * The tests/type-compatibility.ts suite fails if @types/pg gains a property
+ * or signature this shim lacks. When that happens;
+ * - Check the failing assertion name (e.g. _ClientConfigInputCompat) -- the
+ *   tsc error should include the offending key: e.g. `type '"new_key"' does
+ *   not satisfy the constraint 'never'`
+ * - Either mirror the new key verbatim (i.e add it to this file) or widen it
+ *   (perhaps to avoid pulling in @types/node) and add a comment
+ *
+ * If you're adding a new shimmed module (not just editing pg/events), remember
+ * that tsconfig.json paths, api-extractor.json bundledPackages, and build.sh
+ * esbuild aliases must all reference it.
+ *
+ * The source of truth for signatures is node_modules/@types/pg/index.d.ts and
+   node_modules/pg-protocol/dist/messages.d.ts (NoticeMessage/DatabaseError).
  */
 
 import { EventEmitter } from 'events';


### PR DESCRIPTION
Three tiny changes:

* Update release instructions in `DEVELOP.md` to account for the new npm `ignore-scripts=true` default
* Update `preversion` script not to insist on being on `main` (because that necessitates extra PRs)
* Following a suggestion in PR #206, add a comment about maintaining the type shims in `shims/pg/index.d.ts`