### PR TITLE
Fix TLS write callback timing

### DIFF
--- a/src/shims/net/index.ts
+++ b/src/shims/net/index.ts
@@ -708,8 +708,10 @@ export class Socket extends EventEmitter {
       });
     } else {
       debug && log('encrypting data:', data);
-      this.tlsWrite!(data);
-      callback();
+      this.tlsWrite!(data).then(
+        () => callback(),
+        (err) => callback(err),
+      );
     }
 
     return true;

--- a/tests/cli/net.test.ts
+++ b/tests/cli/net.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Socket, type subtls } from '../../src/shims/net';
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function createTlsSocket(tlsWrite: (data: Uint8Array) => Promise<void>) {
+  const socket = new Socket();
+  socket.subtls = {
+    TrustedCert: {
+      databaseFromPEM: vi.fn().mockResolvedValue([]),
+    },
+    WebSocketReadQueue: class {
+      read = vi.fn().mockResolvedValue(undefined);
+    },
+    startTls: vi.fn().mockResolvedValue({
+      read: vi.fn().mockResolvedValue(undefined),
+      write: tlsWrite,
+    }),
+  } as unknown as subtls;
+
+  await socket.startTls('localhost');
+  return socket;
+}
+
+describe('Socket TLS writes', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('invokes the callback after the TLS write completes', async () => {
+    vi.stubGlobal('debug', false);
+    const write = deferred<void>();
+    const tlsWrite = vi.fn(() => write.promise);
+    const socket = await createTlsSocket(tlsWrite);
+    const callback = vi.fn();
+    const data = new Uint8Array([1, 2, 3]);
+
+    expect(socket.write(data, 'utf8', callback)).toBe(true);
+    expect(tlsWrite).toHaveBeenCalledWith(data);
+    expect(callback).not.toHaveBeenCalled();
+
+    write.resolve();
+    await write.promise;
+
+    expect(callback).toHaveBeenCalledOnce();
+    expect(callback).toHaveBeenCalledWith();
+  });
+
+  it('passes TLS write errors to the callback', async () => {
+    vi.stubGlobal('debug', false);
+    const write = deferred<void>();
+    const socket = await createTlsSocket(() => write.promise);
+    const error = new Error('TLS write failed');
+    const callbackError = new Promise<unknown>((resolve) => {
+      socket.write(new Uint8Array([1]), 'utf8', (err) => resolve(err));
+    });
+
+    write.reject(error);
+
+    await expect(callbackError).resolves.toBe(error);
+  });
+});


### PR DESCRIPTION
## Summary

- wait for native TLS writes to settle before invoking the socket write callback
- pass TLS write rejections to the callback instead of leaving an unhandled promise rejection
- cover delayed completion and rejection with focused socket tests

## Root cause

The established-TLS branch called `tlsWrite()` without observing its promise and invoked the callback immediately. This reported a completed write before encrypted data was sent and allowed rejected writes to escape as unhandled promise rejections.

Closes #213.

## Validation

- `npx --yes vitest@3.0.7 run tests/cli/net.test.ts --environment=node`
- `npx --yes prettier@3.4.1 --check src/shims/net/index.ts tests/cli/net.test.ts`
- `npx --yes esbuild@0.25.0 src/shims/net/index.ts --bundle --platform=node --format=esm --define:debug=false --outfile=$env:TEMP\serverless-net-shim.mjs`
- `git diff --cached --check`
