### PR TITLE
fix: guard against null ws in Socket.end()

### DIFF
--- a/src/shims/net/index.ts
+++ b/src/shims/net/index.ts
@@ -722,7 +722,7 @@ export class Socket extends EventEmitter {
   ) {
     debug && log('ending socket');
     this.write(data, encoding, () => {
-      this.ws!.close();
+      if (this.ws) this.ws.close();
       callback();
     });
     return this;

--- a/tests/cli/socket.test.ts
+++ b/tests/cli/socket.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from 'vitest';
+import { neonConfig } from '@neondatabase/serverless';
+
+test('end() does not throw when called before the WebSocket is assigned', () => {
+  const socket = new neonConfig();
+  expect(() => socket.end()).not.toThrow();
+});


### PR DESCRIPTION
Fixes #216. Socket.end() called this.ws!.close() with a non-null assertion, but this.ws is null until the WebSocket upgrade resolves, so calling end() before that (e.g. right after construction, since the write callback for an empty buffer fires synchronously) throws a TypeError. Same class of bug as #131, which fixed rawWrite() but missed end().